### PR TITLE
Use dwh domain as custom audience

### DIFF
--- a/pixi.lock
+++ b/pixi.lock
@@ -3941,7 +3941,7 @@ packages:
   timestamp: 1733256829961
 - pypi: .
   name: ecoscope-earthranger-io-core
-  version: 0.0.6.dev0+gc5518f3f2.d20260409
+  version: 0.0.10.dev0+gb2c0d560c.d20260427
   sha256: 1593fda27e78e2525f23d11a10eadafa886a48b6e8f45f6aa18c06463886064a
   requires_dist:
   - geoarrow-pyarrow>=0.2.0,<0.3

--- a/src/ecoscope_earthranger_io_core/client.py
+++ b/src/ecoscope_earthranger_io_core/client.py
@@ -205,7 +205,7 @@ class ERWarehouseClient(BaseModel):
         in cloud environments.
 
         Args:
-            audience: The target audience (the warehouse API base URL).
+            audience: The target audience (the warehouse API domain).
 
         Returns:
             A ``SecretStr``-wrapped Google ID token.
@@ -249,9 +249,14 @@ class ERWarehouseClient(BaseModel):
                 "Ensure _httpx_client() is entered before calling "
                 "_get_auth_headers()."
             )
+        audience = urlparse(base_url).hostname
+        if not audience:
+            raise ValueError(
+                f"Could not extract a valid hostname from warehouse URL: {base_url!r}"
+            )
         return {
             "X-EarthRanger-API-Token": self._token.get_secret_value(),
-            "Authorization": f"Bearer {self._get_id_token(base_url).get_secret_value()}",
+            "Authorization": f"Bearer {self._get_id_token(audience).get_secret_value()}",
         }
 
     async def _fetch_observations_arrow(

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -584,6 +584,17 @@ def test_get_auth_headers_includes_both_tokens() -> None:
     assert headers["Authorization"] == "Bearer mock-id-token"
 
 
+def test_get_auth_headers_raises_on_invalid_warehouse_url() -> None:
+    """Test that _get_auth_headers raises ValueError when hostname cannot be extracted."""
+    er_client = ERWarehouseClient(
+        server="some-site.pamdas.org",
+        token="abc",
+        warehouse_base_url="not-a-url",
+    )
+    with pytest.raises(ValueError, match="Could not extract a valid hostname"):
+        er_client._get_auth_headers()
+
+
 def test_warehouse_base_url_is_optional() -> None:
     """Test that ERWarehouseClient can be constructed without warehouse_base_url."""
     er_client = ERWarehouseClient(


### PR DESCRIPTION
Closes [ERDW-186](https://allenai.atlassian.net/browse/ERDW-186)
This PR changes the audience of google id tokens obtained by the dwh client, to match exactly the dwh api domain, as needed to authorize requests since the last infrastructure changes. 

[ERDW-186]: https://allenai.atlassian.net/browse/ERDW-186?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ