### PR TITLE
Add extra__source to Arrow observation schemas for DWH

### DIFF
--- a/src/ecoscope_earthranger_io_core/arrow.py
+++ b/src/ecoscope_earthranger_io_core/arrow.py
@@ -33,6 +33,7 @@ OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1 = pa.schema(
         ("groupby_col", pa.string()),
         ("extra__subject__name", pa.string()),
         ("extra__subject__subject_subtype", pa.string()),
+        ("extra__source", pa.string()),
         ("junk_status", pa.bool_()),
     ]
 )
@@ -44,6 +45,7 @@ OBSERVATIONS_WITH_PATROL_SCHEMA_SLIM_V1 = pa.schema(
         ("groupby_col", pa.string()),
         ("extra__subject__name", pa.string()),
         ("extra__subject__subject_subtype", pa.string()),
+        ("extra__source", pa.string()),
         ("junk_status", pa.bool_()),
         ("patrol_id", pa.string()),
         ("patrol_title", pa.string()),
@@ -143,6 +145,7 @@ def _observations_pre_cast(earthranger_rb: pa.RecordBatch) -> pa.RecordBatch:
             "location": "geometry",
             "subject_id": "groupby_col",
             "recorded_at": "fixtime",
+            "source_id": "extra__source",
             "subject_name": "extra__subject__name",
             "subject_subtype_id": "extra__subject__subject_subtype",
         }
@@ -231,6 +234,7 @@ TRANSFORMS: dict[SchemaChoices, TransformSpec] = {
             "location",
             "recorded_at",
             "subject_id",
+            "source_id",
             "subject_name",
             "subject_subtype_id",
         ],

--- a/tests/_fastapi_example.py
+++ b/tests/_fastapi_example.py
@@ -33,6 +33,7 @@ OBSERVATIONS_WITH_PATROL_SCHEMA_PERSISTED = pa.schema(
         ("subject_id", pa.string()),
         ("subject_name", pa.string()),
         ("subject_subtype_id", pa.string()),
+        ("source_id", pa.string()),
         ("patrol_id", pa.string()),
         ("patrol_title", pa.string()),
         ("patrol_serial_number", pa.int64()),
@@ -59,6 +60,7 @@ def _patrol_observations_pre_cast(earthranger_rb: pa.RecordBatch) -> pa.RecordBa
             "recorded_at": "fixtime",
             "subject_name": "extra__subject__name",
             "subject_subtype_id": "extra__subject__subject_subtype",
+            "source_id": "extra__source",
             "patrol_type_value": "patrol_type__value",
             "patrol_type_display": "patrol_type__display",
         }
@@ -80,6 +82,7 @@ def _patrol_observations_pre_cast(earthranger_rb: pa.RecordBatch) -> pa.RecordBa
         "groupby_col",
         "extra__subject__name",
         "extra__subject__subject_subtype",
+        "extra__source",
         "junk_status",
         "patrol_id",
         "patrol_title",

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -15,6 +15,12 @@ from ecoscope_earthranger_io_core.query import ObservationsQuery
 from conftest import get_async_rb_generator_from_storage_backend
 
 
+def test_slim_schemas_include_extra_source():
+    """extra__source must be in the slim schemas so downstream can access it."""
+    assert "extra__source" in OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1.names
+    assert "extra__source" in OBSERVATIONS_WITH_PATROL_SCHEMA_SLIM_V1.names
+
+
 @pytest.mark.parametrize(
     "schema",
     [
@@ -53,3 +59,31 @@ async def test_generate_bytes():
     source = sink.getvalue()
     table = pa.ipc.open_stream(source).read_all()
     assert table.num_rows > 0
+
+
+@pytest.mark.asyncio
+async def test_generate_bytes_includes_extra_source():
+    """The ECOSCOPE_SLIM_V1 transform must produce an extra__source column."""
+    transform = TRANSFORMS[SchemaChoices.ECOSCOPE_SLIM_V1]
+    query = ObservationsQuery(
+        tenant_domain="some-site.pamdas.org",
+        subject_ids=["subject1"],
+        range_start=datetime(2023, 1, 1),
+        range_end=datetime(2023, 1, 2),
+    )
+    async_batch_generator = get_async_rb_generator_from_storage_backend(
+        query,
+        columns=transform.required_columns,
+        schema=transform.pre_transform_schema,
+    )
+    content_stream = transform.generate_bytes(
+        async_batch_generator=async_batch_generator()
+    )
+    sink = io.BytesIO()
+    async for chunk in content_stream:
+        sink.write(chunk)
+    sink.seek(0)
+    table = pa.ipc.open_stream(sink).read_all()
+    assert "extra__source" in table.schema.names
+    source_values = table.column("extra__source").to_pylist()
+    assert all(v is not None for v in source_values)


### PR DESCRIPTION
This PR:  
  - Adds `extra__source` field to `ECOSCOPE_SLIM_V1` and `OBSERVATIONS_WITH_PATROL_SCHEMA_SLIM_V1` target schemas
  - Adds `source_id` to `_observations_pre_cast` rename mapping and `ECOSCOPE_SLIM_V1` required_columns                                                                    
  - Updates tests and pre-cast functions to match          
  
 Related to [ERDW-194](https://allenai.atlassian.net/browse/ERDW-194)

[ERDW-194]: https://allenai.atlassian.net/browse/ERDW-194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ