### PR TITLE
ERDW-155: Support filtering observations by exclusion flags in the DWH client

### DIFF
--- a/src/ecoscope_earthranger_io_core/client.py
+++ b/src/ecoscope_earthranger_io_core/client.py
@@ -324,6 +324,7 @@ class ERWarehouseClient(BaseModel):
         since: str | None = None,
         until: str | None = None,
         query_engine: QueryEngine | None = None,
+        filter: int | None = None,
     ) -> pa.Table:
         """Get observations for a subject group from EarthRanger Data Warehouse.
 
@@ -351,6 +352,7 @@ class ERWarehouseClient(BaseModel):
             range_start=datetime.fromisoformat(since),
             range_end=datetime.fromisoformat(until),
             subject_group_name=subject_group_name,
+            exclusion_flags=filter,
         )
         table = self._run_async(
             self._fetch_observations_arrow(query, query_engine=engine)
@@ -366,6 +368,7 @@ class ERWarehouseClient(BaseModel):
         include_patrol_details: bool = True,
         sub_page_size: int | None = None,
         query_engine: QueryEngine | None = None,
+        filter: int | None = None,
     ) -> pa.Table:
         """Get patrol observations filtered by patrol type and status.
 
@@ -394,6 +397,7 @@ class ERWarehouseClient(BaseModel):
             patrol_type_value=patrol_type_value,
             patrol_status=status,  # type: ignore[arg-type]
             include_patrol_details=include_patrol_details,
+            exclusion_flags=filter,
         )
         table = self._run_async(
             self._fetch_observations_arrow(query, query_engine=engine)
@@ -446,6 +450,7 @@ class ERWarehouseClient(BaseModel):
         include_patrol_details: bool = True,
         sub_page_size: int | None = None,
         query_engine: QueryEngine | None = None,
+        filter: int | None = None,
     ) -> pa.Table:
         """Get observations for patrols from EarthRanger Data Warehouse.
 
@@ -472,6 +477,7 @@ class ERWarehouseClient(BaseModel):
             tenant_domain=self.server,
             patrol_ids=list(set(patrol_ids)),
             include_patrol_details=include_patrol_details,
+            exclusion_flags=filter,
         )
         return self._run_async(
             self._fetch_observations_arrow(query, query_engine=engine)

--- a/src/ecoscope_earthranger_io_core/query.py
+++ b/src/ecoscope_earthranger_io_core/query.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from typing import Literal
 
 from fastapi import Query
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 QueryEngine = Literal["auto", "iceberg-bq", "iceberg-dd"]
 
@@ -53,6 +53,14 @@ class ObservationsQuery(_WarehouseQuery):
     patrol_type_value: list[str] | None = None
     patrol_status: list[PatrolStatus] | None = None
     include_patrol_details: bool = False
+    exclusion_flags: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Bitmask filter. None=no filter, 0=clean only, "
+            ">0=AND with bitmask must be >0."
+        ),
+    )
 
     @classmethod
     def from_query_params(
@@ -66,6 +74,14 @@ class ObservationsQuery(_WarehouseQuery):
         patrol_type_value: list[str] | None = Query(None),
         patrol_status: list[PatrolStatus] | None = Query(None),
         include_patrol_details: bool = Query(False),
+        exclusion_flags: int | None = Query(
+            None,
+            ge=0,
+            description=(
+                "Bitmask filter. None=no filter, 0=clean only, "
+                ">0=AND with bitmask must be >0."
+            ),
+        ),
     ) -> "ObservationsQuery":
         return cls(
             tenant_domain=tenant_domain,
@@ -77,6 +93,7 @@ class ObservationsQuery(_WarehouseQuery):
             patrol_type_value=patrol_type_value,
             patrol_status=patrol_status,
             include_patrol_details=include_patrol_details,
+            exclusion_flags=exclusion_flags,
         )
 
 

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -654,3 +654,104 @@ def test_server_field_rejects_invalid_input(raw_server: str) -> None:
             token="abc",
             warehouse_base_url="http://test",
         )
+
+
+# -------------------------------------------------------------------------
+# exclusion_flags forwarding tests
+# -------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [None, 0, 1, 2, 3])
+def test_client_get_subjectgroup_observations_forwards_exclusion_flags(
+    app: FastAPI,
+    value,
+) -> None:
+    """``exclusion_flags`` should reach the query string of the mocked backend."""
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def _mock_httpx_client(self):
+        async with AsyncClient(
+            transport=ASGITransport(app),
+            base_url="http://test",
+        ) as mock_httpx_client:
+            original_stream = mock_httpx_client.stream
+
+            def _capturing_stream(method, url, **kwargs):
+                captured["params"] = kwargs.get("params")
+                return original_stream(method, url, **kwargs)
+
+            mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
+            yield mock_httpx_client
+
+    with patch.object(
+        ERWarehouseClient,
+        "_httpx_client",
+        _mock_httpx_client,
+    ):
+        er_client = ERWarehouseClient(
+            server="some-site.pamdas.org",
+            token="abc",
+            warehouse_base_url="http://test",
+        )
+        er_client.get_subjectgroup_observations(
+            subject_group_name="Ecoscope",
+            since="2015-01-01T12:00:00",
+            until="2015-03-01T12:00:00",
+            filter=value,
+        )
+
+    params = captured["params"]
+    if value is None:
+        assert "exclusion_flags" not in params
+    else:
+        assert params["exclusion_flags"] == value
+
+
+@pytest.mark.parametrize("value", [None, 0, 1, 2, 3])
+def test_client_get_patrol_observations_with_patrol_filter_forwards_exclusion_flags(
+    app: FastAPI,
+    value,
+) -> None:
+    """patrol-filtered observations must also forward ``exclusion_flags``."""
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def _mock_httpx_client(self):
+        async with AsyncClient(
+            transport=ASGITransport(app),
+            base_url="http://test",
+        ) as mock_httpx_client:
+            original_stream = mock_httpx_client.stream
+
+            def _capturing_stream(method, url, **kwargs):
+                captured["params"] = kwargs.get("params")
+                return original_stream(method, url, **kwargs)
+
+            mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
+            yield mock_httpx_client
+
+    with patch.object(
+        ERWarehouseClient,
+        "_httpx_client",
+        _mock_httpx_client,
+    ):
+        er_client = ERWarehouseClient(
+            server="some-site.pamdas.org",
+            token="abc",
+            warehouse_base_url="http://test",
+        )
+        er_client.get_patrol_observations_with_patrol_filter(
+            since="2015-01-01T12:00:00",
+            until="2015-03-01T12:00:00",
+            patrol_type_value=["routine_patrol"],
+            status=["done"],
+            include_patrol_details=True,
+            filter=value,
+        )
+
+    params = captured["params"]
+    if value is None:
+        assert "exclusion_flags" not in params
+    else:
+        assert params["exclusion_flags"] == value

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -7,38 +7,38 @@ from ecoscope_earthranger_io_core.query import ObservationsQuery
 def test_observations(): ...
 
 
-class TestObservationsQueryExclusionFlags:
-    """Verify the ``exclusion_flags`` field on the shared query model."""
+@pytest.mark.parametrize("value", [None, 0, 1, 2, 3])
+def test_observations_query_exclusion_flags_round_trip(value):
+    q = ObservationsQuery(tenant_domain="example.pamdas.org", exclusion_flags=value)
+    assert q.exclusion_flags == value
+    assert q.model_dump()["exclusion_flags"] == value
 
-    @pytest.mark.parametrize("value", [None, 0, 1, 2, 3])
-    def test_round_trip(self, value):
-        q = ObservationsQuery(tenant_domain="example.pamdas.org", exclusion_flags=value)
-        assert q.exclusion_flags == value
-        assert q.model_dump()["exclusion_flags"] == value
 
-    def test_default_is_none(self):
-        q = ObservationsQuery(tenant_domain="example.pamdas.org")
-        assert q.exclusion_flags is None
+def test_observations_query_exclusion_flags_default_is_none():
+    q = ObservationsQuery(tenant_domain="example.pamdas.org")
+    assert q.exclusion_flags is None
 
-    @pytest.mark.parametrize("value", [None, 0, 1, 2, 3])
-    def test_from_query_params_round_trip(self, value):
-        # ``from_query_params`` is a FastAPI dependency; when called directly
-        # we must pass every parameter explicitly so the ``Query(...)``
-        # sentinels don't leak into pydantic.
-        q = ObservationsQuery.from_query_params(
-            tenant_domain="example.pamdas.org",
-            range_start=None,
-            range_end=None,
-            subject_ids=None,
-            subject_group_name=None,
-            patrol_ids=None,
-            patrol_type_value=None,
-            patrol_status=None,
-            include_patrol_details=False,
-            exclusion_flags=value,
-        )
-        assert q.exclusion_flags == value
 
-    def test_negative_value_rejected(self):
-        with pytest.raises(ValidationError):
-            ObservationsQuery(tenant_domain="example.pamdas.org", exclusion_flags=-1)
+@pytest.mark.parametrize("value", [None, 0, 1, 2, 3])
+def test_observations_query_from_query_params_round_trip(value):
+    # ``from_query_params`` is a FastAPI dependency; when called directly
+    # we must pass every parameter explicitly so the ``Query(...)``
+    # sentinels don't leak into pydantic.
+    q = ObservationsQuery.from_query_params(
+        tenant_domain="example.pamdas.org",
+        range_start=None,
+        range_end=None,
+        subject_ids=None,
+        subject_group_name=None,
+        patrol_ids=None,
+        patrol_type_value=None,
+        patrol_status=None,
+        include_patrol_details=False,
+        exclusion_flags=value,
+    )
+    assert q.exclusion_flags == value
+
+
+def test_observations_query_exclusion_flags_negative_value_rejected():
+    with pytest.raises(ValidationError):
+        ObservationsQuery(tenant_domain="example.pamdas.org", exclusion_flags=-1)

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,1 +1,44 @@
+import pytest
+from pydantic import ValidationError
+
+from ecoscope_earthranger_io_core.query import ObservationsQuery
+
+
 def test_observations(): ...
+
+
+class TestObservationsQueryExclusionFlags:
+    """Verify the ``exclusion_flags`` field on the shared query model."""
+
+    @pytest.mark.parametrize("value", [None, 0, 1, 2, 3])
+    def test_round_trip(self, value):
+        q = ObservationsQuery(tenant_domain="example.pamdas.org", exclusion_flags=value)
+        assert q.exclusion_flags == value
+        assert q.model_dump()["exclusion_flags"] == value
+
+    def test_default_is_none(self):
+        q = ObservationsQuery(tenant_domain="example.pamdas.org")
+        assert q.exclusion_flags is None
+
+    @pytest.mark.parametrize("value", [None, 0, 1, 2, 3])
+    def test_from_query_params_round_trip(self, value):
+        # ``from_query_params`` is a FastAPI dependency; when called directly
+        # we must pass every parameter explicitly so the ``Query(...)``
+        # sentinels don't leak into pydantic.
+        q = ObservationsQuery.from_query_params(
+            tenant_domain="example.pamdas.org",
+            range_start=None,
+            range_end=None,
+            subject_ids=None,
+            subject_group_name=None,
+            patrol_ids=None,
+            patrol_type_value=None,
+            patrol_status=None,
+            include_patrol_details=False,
+            exclusion_flags=value,
+        )
+        assert q.exclusion_flags == value
+
+    def test_negative_value_rejected(self):
+        with pytest.raises(ValidationError):
+            ObservationsQuery(tenant_domain="example.pamdas.org", exclusion_flags=-1)


### PR DESCRIPTION
This PR updates query models and the DWH client to support filtering observations by exclusion flags as the ER client does.

**[Below a changelog generated with `/er-developer:branch-changes` (experimental)]**

## At a glance

* **Range:** `main..mm/erdw-155-exclusion-flags` ([compare](https://github.com/wildlife-dynamics/ecoscope-earthranger-io-core/compare/main...mm/erdw-155-exclusion-flags))
* **Merged PRs:** 0 (branch has not been opened as a PR yet; 2 direct commits)
* **Authors:** Mariano Martinez Grasso
* **Linked tickets:** [ERDW-155](https://allenai.atlassian.net/browse/ERDW-155) (inferred from branch name; Jira summary not fetched)
* **Breaking changes:** no

## Breaking changes

_None._ The new `filter` kwarg on `ERWarehouseClient.get_*_observations` methods defaults to `None`; existing callers are unaffected. The new `ObservationsQuery.exclusion_flags` field also defaults to `None` and is omitted from the wire payload by `model_dump(exclude_none=True)`, so the warehouse API contract is additive.

## Changes by area

### `ERWarehouseClient` (client.py)

* **Add `filter: int | None = None` kwarg to three observation methods** — Mariano Martinez Grasso. (`ae2e60f`)
  Applies to `get_subjectgroup_observations`, `get_patrol_observations_with_patrol_filter`, and `get_patrol_observations`. The kwarg name matches the legacy `EarthRangerIO` / `EarthRangerClientProtocol` interface; the value is mapped internally to `exclusion_flags=<int>` when constructing the `ObservationsQuery`, so the wire-level URL parameter remains `exclusion_flags`.

### Query models (query.py)

* **Add `exclusion_flags: int | None` field to `ObservationsQuery`** — Mariano Martinez Grasso. (`ae2e60f`)
  Validated with `ge=0`. Bitmask semantics per the field description: `None` = no filter, `0` = clean only, `>0` = bitmask AND. Exposed via the FastAPI `from_query_params` dependency as `exclusion_flags: int | None = Query(None, ge=0, ...)`.

### Tests

* **Add `filter`-forwarding tests in `test_ipc.py`** — Mariano Martinez Grasso. (`ae2e60f`)
  Two parametrized tests (`[None, 0, 1, 2, 3]`) verify that `ERWarehouseClient.get_subjectgroup_observations(..., filter=value)` and `ERWarehouseClient.get_patrol_observations_with_patrol_filter(..., filter=value)` propagate to the URL query string as `exclusion_flags=<value>`, and that `None` is omitted from the params dict.
* **Add `ObservationsQuery.exclusion_flags` field tests in `test_query.py`** — Mariano Martinez Grasso. (`ae2e60f`)
  Covers round-trip on the model, default-is-None, `from_query_params` round-trip, and negative-value rejection (`ValidationError`).
* **Flatten test classes in `test_query.py` to plain functions** — Mariano Martinez Grasso. (`a2d9386`)
  Drops `TestObservationsQueryExclusionFlags` in favor of four module-level `test_observations_query_*` functions, matching the plain-function convention used in `test_arrow.py`, `test_dataframe.py`, and `test_ipc.py`.

## Dependency bumps

_None._

## Tests, CI, infra

_None._ All test changes are functional coverage for the new field/kwarg and are listed under **Tests** above.

## Commits

* `ae2e60f` — Support obs exclusion flags filter in the DWH client — Mariano Martinez Grasso.
* `a2d9386` — Flatten tests around obs exclusion flags for DWH — Mariano Martinez Grasso.

## Caveats

* The wire-level URL parameter sent to the warehouse API is `exclusion_flags=<int>`. The receiving FastAPI endpoint in `earthranger-warehouse-api` must accept this parameter name and apply the bitmask correctly — that change is **out of scope for this repo** and must land separately. If the warehouse API does not yet recognize `exclusion_flags`, the parameter will be silently ignored server-side.
* The `filter` → `exclusion_flags` semantic contract is documented as "bitmask AND" in the new field description, but the legacy `EarthRangerIO` docstring describes discrete `0`/`1`/`2`/`3` cases. The two interpretations coincide for those values; behavior for any other positive integer depends on what the warehouse API actually executes.
* The companion change in `ecoscope/platform/tasks/io/_earthranger.py` (mapping the task-layer `ExclusionFilter` string literal via `_EXCLUSION_FILTER_TO_INT` and passing `filter=filter_int` to `warehouse_client.get_subjectgroup_observations(...)`) lives in the **ecoscope** repo on branch `mm/update-io-core-v0.0.11` and is not reflected in this changelog.

---

_Generated by the `branch-changes` skill. Source data: git log


[ERDW-155]: https://allenai.atlassian.net/browse/ERDW-155?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ