### PR TITLE
Support patrols_overlap_daterange param in the DWH client

### DIFF
--- a/src/ecoscope_earthranger_io_core/client.py
+++ b/src/ecoscope_earthranger_io_core/client.py
@@ -367,6 +367,7 @@ class ERWarehouseClient(BaseModel):
         status: list[str] | None = None,
         include_patrol_details: bool = True,
         sub_page_size: int | None = None,
+        patrols_overlap_daterange: bool = True,
         query_engine: QueryEngine | None = None,
         filter: int | None = None,
     ) -> pa.Table:
@@ -379,6 +380,9 @@ class ERWarehouseClient(BaseModel):
             status: List of patrol statuses to filter by (e.g., ["done"]).
             include_patrol_details: Whether to include patrol metadata.
             sub_page_size: Ignored (for interface compatibility).
+            patrols_overlap_daterange: If True (default), include patrols
+                whose time range overlaps [since, until]; if False, include
+                only patrols starting within that range.
             query_engine: Backend engine to use. Defaults to the client-level
                 setting (``self.query_engine``).
 
@@ -396,6 +400,7 @@ class ERWarehouseClient(BaseModel):
             range_end=datetime.fromisoformat(until),
             patrol_type_value=patrol_type_value,
             patrol_status=status,  # type: ignore[arg-type]
+            patrols_overlap_daterange=patrols_overlap_daterange,
             include_patrol_details=include_patrol_details,
             exclusion_flags=filter,
         )
@@ -411,6 +416,7 @@ class ERWarehouseClient(BaseModel):
         patrol_type_value: list[str] | None = None,
         status: list[str] | None = None,
         sub_page_size: int | None = None,
+        patrols_overlap_daterange: bool = True,
         query_engine: QueryEngine | None = None,
     ) -> pa.Table:
         """Get minimal patrol data from EarthRanger Data Warehouse.
@@ -427,6 +433,9 @@ class ERWarehouseClient(BaseModel):
             patrol_type_value: List of patrol type values to filter by.
             status: List of patrol statuses to filter by (e.g., ["done"]).
             sub_page_size: Ignored (for interface compatibility).
+            patrols_overlap_daterange: If True (default), include patrols
+                whose time range overlaps [since, until]; if False, include
+                only patrols starting within that range.
             query_engine: Backend engine to use. Defaults to the client-level
                 setting (``self.query_engine``).
 
@@ -441,6 +450,7 @@ class ERWarehouseClient(BaseModel):
             range_end=datetime.fromisoformat(until),
             patrol_type_value=patrol_type_value,
             patrol_status=status,
+            patrols_overlap_daterange=patrols_overlap_daterange,
         )
         return self._run_async(self._fetch_patrols_arrow(query, query_engine=engine))
 

--- a/src/ecoscope_earthranger_io_core/query.py
+++ b/src/ecoscope_earthranger_io_core/query.py
@@ -16,6 +16,13 @@ class _WarehouseQuery(BaseModel):
 PatrolStatus = Literal["active", "overdue", "done", "cancelled"]
 
 
+_PATROLS_OVERLAP_DATERANGE_DESCRIPTION = (
+    "If True (default), include patrols whose time range overlaps "
+    "[range_start, range_end]; if False, include only patrols "
+    "starting within that range."
+)
+
+
 class ObservationsQuery(_WarehouseQuery):
     """An EarthRanger observations query.
 
@@ -52,6 +59,10 @@ class ObservationsQuery(_WarehouseQuery):
     patrol_ids: list[str] | None = None
     patrol_type_value: list[str] | None = None
     patrol_status: list[PatrolStatus] | None = None
+    patrols_overlap_daterange: bool = Field(
+        default=True,
+        description=_PATROLS_OVERLAP_DATERANGE_DESCRIPTION,
+    )
     include_patrol_details: bool = False
     exclusion_flags: int | None = Field(
         default=None,
@@ -73,6 +84,7 @@ class ObservationsQuery(_WarehouseQuery):
         patrol_ids: list[str] | None = Query(None),
         patrol_type_value: list[str] | None = Query(None),
         patrol_status: list[PatrolStatus] | None = Query(None),
+        patrols_overlap_daterange: bool = Query(True),
         include_patrol_details: bool = Query(False),
         exclusion_flags: int | None = Query(
             None,
@@ -92,6 +104,7 @@ class ObservationsQuery(_WarehouseQuery):
             patrol_ids=patrol_ids,
             patrol_type_value=patrol_type_value,
             patrol_status=patrol_status,
+            patrols_overlap_daterange=patrols_overlap_daterange,
             include_patrol_details=include_patrol_details,
             exclusion_flags=exclusion_flags,
         )
@@ -138,6 +151,10 @@ class PatrolsQuery(_WarehouseQuery):
     patrol_ids: list[str] | None = None
     patrol_type_value: list[str] | None = None
     patrol_status: list[PatrolStatus] | None = None
+    patrols_overlap_daterange: bool = Field(
+        default=True,
+        description=_PATROLS_OVERLAP_DATERANGE_DESCRIPTION,
+    )
     include_patrol_segments: bool = False
     flat: bool = True
 
@@ -150,6 +167,7 @@ class PatrolsQuery(_WarehouseQuery):
         patrol_ids: list[str] | None = Query(None),
         patrol_type_value: list[str] | None = Query(None),
         patrol_status: list[PatrolStatus] | None = Query(None),
+        patrols_overlap_daterange: bool = Query(True),
         include_patrol_segments: bool = Query(False),
         flat: bool = Query(True),
     ) -> "PatrolsQuery":
@@ -160,6 +178,7 @@ class PatrolsQuery(_WarehouseQuery):
             patrol_ids=patrol_ids,
             patrol_type_value=patrol_type_value,
             patrol_status=patrol_status,
+            patrols_overlap_daterange=patrols_overlap_daterange,
             include_patrol_segments=include_patrol_segments,
             flat=flat,
         )

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -755,3 +755,184 @@ def test_client_get_patrol_observations_with_patrol_filter_forwards_exclusion_fl
         assert "exclusion_flags" not in params
     else:
         assert params["exclusion_flags"] == value
+
+
+# -------------------------------------------------------------------------
+# patrols_overlap_daterange forwarding tests
+# -------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_client_get_patrol_observations_with_patrol_filter_forwards_patrols_overlap_daterange(
+    app: FastAPI,
+    value,
+) -> None:
+    """patrol-filtered observations must forward ``patrols_overlap_daterange``."""
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def _mock_httpx_client(self):
+        async with AsyncClient(
+            transport=ASGITransport(app),
+            base_url="http://test",
+        ) as mock_httpx_client:
+            original_stream = mock_httpx_client.stream
+
+            def _capturing_stream(method, url, **kwargs):
+                captured["params"] = kwargs.get("params")
+                return original_stream(method, url, **kwargs)
+
+            mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
+            yield mock_httpx_client
+
+    with patch.object(
+        ERWarehouseClient,
+        "_httpx_client",
+        _mock_httpx_client,
+    ):
+        er_client = ERWarehouseClient(
+            server="some-site.pamdas.org",
+            token="abc",
+            warehouse_base_url="http://test",
+        )
+        er_client.get_patrol_observations_with_patrol_filter(
+            since="2015-01-01T12:00:00",
+            until="2015-03-01T12:00:00",
+            patrol_type_value=["routine_patrol"],
+            status=["done"],
+            patrols_overlap_daterange=value,
+            include_patrol_details=True,
+        )
+
+    params = captured["params"]
+    assert params["patrols_overlap_daterange"] == value
+
+
+def test_client_get_patrol_observations_with_patrol_filter_default_patrols_overlap_daterange_is_true(
+    app: FastAPI,
+) -> None:
+    """When the caller omits ``patrols_overlap_daterange`` it should default to True."""
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def _mock_httpx_client(self):
+        async with AsyncClient(
+            transport=ASGITransport(app),
+            base_url="http://test",
+        ) as mock_httpx_client:
+            original_stream = mock_httpx_client.stream
+
+            def _capturing_stream(method, url, **kwargs):
+                captured["params"] = kwargs.get("params")
+                return original_stream(method, url, **kwargs)
+
+            mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
+            yield mock_httpx_client
+
+    with patch.object(
+        ERWarehouseClient,
+        "_httpx_client",
+        _mock_httpx_client,
+    ):
+        er_client = ERWarehouseClient(
+            server="some-site.pamdas.org",
+            token="abc",
+            warehouse_base_url="http://test",
+        )
+        er_client.get_patrol_observations_with_patrol_filter(
+            since="2015-01-01T12:00:00",
+            until="2015-03-01T12:00:00",
+            patrol_type_value=["routine_patrol"],
+            status=["done"],
+            include_patrol_details=True,
+        )
+
+    params = captured["params"]
+    assert params["patrols_overlap_daterange"] is True
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_client_get_patrols_minimal_forwards_patrols_overlap_daterange(
+    app: FastAPI,
+    value,
+) -> None:
+    """``get_patrols_minimal`` must forward ``patrols_overlap_daterange``."""
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def _mock_httpx_client(self):
+        async with AsyncClient(
+            transport=ASGITransport(app),
+            base_url="http://test",
+        ) as mock_httpx_client:
+            original_stream = mock_httpx_client.stream
+
+            def _capturing_stream(method, url, **kwargs):
+                captured["params"] = kwargs.get("params")
+                return original_stream(method, url, **kwargs)
+
+            mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
+            yield mock_httpx_client
+
+    with patch.object(
+        ERWarehouseClient,
+        "_httpx_client",
+        _mock_httpx_client,
+    ):
+        er_client = ERWarehouseClient(
+            server="some-site.pamdas.org",
+            token="abc",
+            warehouse_base_url="http://test",
+        )
+        er_client.get_patrols_minimal(
+            since="2015-01-01T12:00:00",
+            until="2015-03-01T12:00:00",
+            patrol_type_value=["routine_patrol"],
+            status=["done"],
+            patrols_overlap_daterange=value,
+        )
+
+    params = captured["params"]
+    assert params["patrols_overlap_daterange"] == value
+
+
+def test_client_get_patrols_minimal_default_patrols_overlap_daterange_is_true(
+    app: FastAPI,
+) -> None:
+    """When the caller omits ``patrols_overlap_daterange`` it should default to True."""
+    captured: dict = {}
+
+    @asynccontextmanager
+    async def _mock_httpx_client(self):
+        async with AsyncClient(
+            transport=ASGITransport(app),
+            base_url="http://test",
+        ) as mock_httpx_client:
+            original_stream = mock_httpx_client.stream
+
+            def _capturing_stream(method, url, **kwargs):
+                captured["params"] = kwargs.get("params")
+                return original_stream(method, url, **kwargs)
+
+            mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
+            yield mock_httpx_client
+
+    with patch.object(
+        ERWarehouseClient,
+        "_httpx_client",
+        _mock_httpx_client,
+    ):
+        er_client = ERWarehouseClient(
+            server="some-site.pamdas.org",
+            token="abc",
+            warehouse_base_url="http://test",
+        )
+        er_client.get_patrols_minimal(
+            since="2015-01-01T12:00:00",
+            until="2015-03-01T12:00:00",
+            patrol_type_value=["routine_patrol"],
+            status=["done"],
+        )
+
+    params = captured["params"]
+    assert params["patrols_overlap_daterange"] is True

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -1,7 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from ecoscope_earthranger_io_core.query import ObservationsQuery
+from ecoscope_earthranger_io_core.query import ObservationsQuery, PatrolsQuery
 
 
 def test_observations(): ...
@@ -33,6 +33,7 @@ def test_observations_query_from_query_params_round_trip(value):
         patrol_ids=None,
         patrol_type_value=None,
         patrol_status=None,
+        patrols_overlap_daterange=True,
         include_patrol_details=False,
         exclusion_flags=value,
     )
@@ -42,3 +43,71 @@ def test_observations_query_from_query_params_round_trip(value):
 def test_observations_query_exclusion_flags_negative_value_rejected():
     with pytest.raises(ValidationError):
         ObservationsQuery(tenant_domain="example.pamdas.org", exclusion_flags=-1)
+
+
+def test_observations_query_patrols_overlap_daterange_default_is_true():
+    q = ObservationsQuery(tenant_domain="example.pamdas.org")
+    assert q.patrols_overlap_daterange is True
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_observations_query_patrols_overlap_daterange_round_trip(value):
+    q = ObservationsQuery(
+        tenant_domain="example.pamdas.org", patrols_overlap_daterange=value
+    )
+    assert q.patrols_overlap_daterange is value
+    assert q.model_dump()["patrols_overlap_daterange"] is value
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_observations_query_from_query_params_patrols_overlap_daterange(value):
+    # ``from_query_params`` is a FastAPI dependency; when called directly
+    # we must pass every parameter explicitly so the ``Query(...)``
+    # sentinels don't leak into pydantic.
+    q = ObservationsQuery.from_query_params(
+        tenant_domain="example.pamdas.org",
+        range_start=None,
+        range_end=None,
+        subject_ids=None,
+        subject_group_name=None,
+        patrol_ids=None,
+        patrol_type_value=None,
+        patrol_status=None,
+        patrols_overlap_daterange=value,
+        include_patrol_details=False,
+        exclusion_flags=None,
+    )
+    assert q.patrols_overlap_daterange is value
+
+
+def test_patrols_query_patrols_overlap_daterange_default_is_true():
+    q = PatrolsQuery(tenant_domain="example.pamdas.org")
+    assert q.patrols_overlap_daterange is True
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_patrols_query_patrols_overlap_daterange_round_trip(value):
+    q = PatrolsQuery(
+        tenant_domain="example.pamdas.org", patrols_overlap_daterange=value
+    )
+    assert q.patrols_overlap_daterange is value
+    assert q.model_dump()["patrols_overlap_daterange"] is value
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_patrols_query_from_query_params_patrols_overlap_daterange(value):
+    # ``from_query_params`` is a FastAPI dependency; when called directly
+    # we must pass every parameter explicitly so the ``Query(...)``
+    # sentinels don't leak into pydantic.
+    q = PatrolsQuery.from_query_params(
+        tenant_domain="example.pamdas.org",
+        range_start=None,
+        range_end=None,
+        patrol_ids=None,
+        patrol_type_value=None,
+        patrol_status=None,
+        patrols_overlap_daterange=value,
+        include_patrol_segments=False,
+        flat=True,
+    )
+    assert q.patrols_overlap_daterange is value


### PR DESCRIPTION
### Summary
Closes [ERDW-156](https://allenai.atlassian.net/browse/ERDW-156).

Adds a `patrols_overlap_daterange: bool = True` parameter to `ObservationsQuery`, `PatrolsQuery`, `ERWarehouseClient.get_patrol_observations_with_patrol_filter`, and  `ERWarehouseClient.get_patrols_minimal`, mirroring the same flag on `EarthRangerIO.get_patrol_observations_with_patrol_filter / get_patrols` so callers can opt into the  "patrols starting within the range" semantics (=False) instead of the default overlap semantics (=True). Purely additive contract surface — defaults preserve current  behavior and no existing call site needs to change. The server-side SQL branching that interprets =False lives in the `earthranger-warehouse-api` repo and will land  in a follow-up PR pinned to `v0.0.16` of this package; until then the parameter is forwarded but ignored, and =False returns the same result as =True. Note that every outbound request will now carry patrols_overlap_daterange=true in the query string by default (harmless: FastAPI ignores unknown params on older API instances).


[ERDW-156]: https://allenai.atlassian.net/browse/ERDW-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ