### PR TITLE
ERDW-261: Add category_display and patrol leader_name to event schemas

### DIFF
--- a/src/ecoscope_earthranger_io_core/arrow.py
+++ b/src/ecoscope_earthranger_io_core/arrow.py
@@ -210,11 +210,16 @@ PATROL_EVENT_STRUCT_V1 = pa.struct(
 )
 
 # Patrol-segment struct carrying its events. This is the segment struct used by
-# the with-events schema only: it is PATROL_SEGMENT_STRUCT_V1's fields plus a
-# trailing ``events`` list. PATROL_SEGMENT_STRUCT_V1 itself is left untouched.
+# the with-events schema only: it is PATROL_SEGMENT_STRUCT_V1's fields plus the
+# resolved segment ``leader_name`` (from a subjects join on ``leader_id``) and a
+# trailing ``events`` list. PATROL_SEGMENT_STRUCT_V1 itself is left untouched, so
+# the lean/flat patrols schemas do not require the leader-name resolution.
 PATROL_SEGMENT_WITH_EVENTS_STRUCT_V1 = pa.struct(
     list(PATROL_SEGMENT_STRUCT_V1)
-    + [pa.field("events", pa.list_(PATROL_EVENT_STRUCT_V1))]
+    + [
+        pa.field("leader_name", pa.string()),
+        pa.field("events", pa.list_(PATROL_EVENT_STRUCT_V1)),
+    ]
 )
 
 # Nested patrols schema WITH events — selected only when include_events=true.
@@ -271,6 +276,7 @@ EVENT_TYPES_SCHEMA_V1 = pa.schema(
         ("value", pa.string()),
         ("display", pa.string()),
         ("category_value", pa.string()),
+        ("category_display", pa.string()),
         ("is_active", pa.bool_()),
         ("is_collection", pa.bool_()),
     ]

--- a/src/ecoscope_earthranger_io_core/client.py
+++ b/src/ecoscope_earthranger_io_core/client.py
@@ -805,8 +805,9 @@ class ERWarehouseClient(BaseModel):
     def get_event_types(self, query_engine: QueryEngine | None = None) -> pa.Table:
         """Get event types from the EarthRanger Data Warehouse.
 
-        The returned table provides the ``value`` -> ``display`` mapping used to
-        resolve event type display names.
+        The returned table provides the ``value`` -> ``display`` (and
+        ``category_value`` -> ``category_display``) mapping used to resolve event
+        type and category display names.
 
         Args:
             query_engine: Backend engine to use. Defaults to the client-level
@@ -814,7 +815,8 @@ class ERWarehouseClient(BaseModel):
 
         Returns:
             PyArrow Table with event types. Schema: EVENT_TYPES_SCHEMA_V1
-            (id, value, display, category_value, is_active, is_collection).
+            (id, value, display, category_value, category_display, is_active,
+            is_collection).
         """
         engine = query_engine or self.query_engine
         query = EventTypesQuery(tenant_domain=self.server)

--- a/tests/_fastapi_example.py
+++ b/tests/_fastapi_example.py
@@ -191,6 +191,7 @@ def _build_patrols_with_events_record_batch() -> pa.RecordBatch:
         "scheduled_end": "2015-01-01T14:00:00+00:00",
         "start_location": None,
         "end_location": None,
+        "leader_name": "Ranger Zero",
         "events": [event],
     }
     patrol = {
@@ -374,6 +375,7 @@ def _build_event_types_record_batch() -> pa.RecordBatch:
             "value": "wildlife_sighting",
             "display": "Wildlife Sighting",
             "category_value": "monitoring",
+            "category_display": "Monitoring",
             "is_active": True,
             "is_collection": False,
         },
@@ -382,6 +384,7 @@ def _build_event_types_record_batch() -> pa.RecordBatch:
             "value": "poaching",
             "display": "Poaching",
             "category_value": "security",
+            "category_display": "Security",
             "is_active": True,
             "is_collection": False,
         },

--- a/tests/test_events_arrow.py
+++ b/tests/test_events_arrow.py
@@ -50,6 +50,7 @@ def test_event_types_schema_v1_fields():
         ("value", pa.string()),
         ("display", pa.string()),
         ("category_value", pa.string()),
+        ("category_display", pa.string()),
         ("is_active", pa.bool_()),
         ("is_collection", pa.bool_()),
     ]
@@ -132,8 +133,8 @@ def test_patrol_event_struct_v1_fields():
 
 
 def test_patrol_segment_with_events_struct_v1_fields():
-    """The with-events segment struct = the lean segment struct's fields plus a
-    trailing events list of PATROL_EVENT_STRUCT_V1."""
+    """The with-events segment struct = the lean segment struct's fields plus the
+    resolved ``leader_name`` and a trailing events list of PATROL_EVENT_STRUCT_V1."""
     segment_names = [
         PATROL_SEGMENT_STRUCT_V1.field(i).name
         for i in range(PATROL_SEGMENT_STRUCT_V1.num_fields)
@@ -142,12 +143,13 @@ def test_patrol_segment_with_events_struct_v1_fields():
         PATROL_SEGMENT_WITH_EVENTS_STRUCT_V1.field(i).name
         for i in range(PATROL_SEGMENT_WITH_EVENTS_STRUCT_V1.num_fields)
     ]
-    assert with_events_names == segment_names + ["events"]
+    assert with_events_names == segment_names + ["leader_name", "events"]
     for name in segment_names:
         assert (
             PATROL_SEGMENT_WITH_EVENTS_STRUCT_V1.field(name).type
             == PATROL_SEGMENT_STRUCT_V1.field(name).type
         )
+    assert PATROL_SEGMENT_WITH_EVENTS_STRUCT_V1.field("leader_name").type == pa.string()
     assert PATROL_SEGMENT_WITH_EVENTS_STRUCT_V1.field("events").type == pa.list_(
         PATROL_EVENT_STRUCT_V1
     )


### PR DESCRIPTION
This PR adds two fields, `category_display` and  `leader_name`, in the arrow schemas related to event data as they are accessed by some workflow tasks or helper functions while consuming event data. A follow-up PR in the DWH API will implement the new schema to serve these new fields

Ref: Usages in ecoscope
[leader_name](https://github.com/wildlife-dynamics/ecoscope/blob/29bcc087586eeecbbdec545268aff935992c57a9/ecoscope/io/earthranger_utils.py#L125)
[category_display](https://github.com/wildlife-dynamics/ecoscope/blob/29bcc087586eeecbbdec545268aff935992c57a9/ecoscope/io/earthranger.py#L868-L890)