### PR TITLE
ERDW-264: Fix issue in the patrol observations schema

### DIFF
--- a/src/ecoscope_earthranger_io_core/arrow.py
+++ b/src/ecoscope_earthranger_io_core/arrow.py
@@ -42,9 +42,12 @@ OBSERVATIONS_WITH_PATROL_SCHEMA_SLIM_V1 = pa.schema(
     [
         ("geometry", geoarrow.pyarrow.wkb().with_crs("EPSG:4326")),
         ("fixtime", pa.timestamp("ns", tz="UTC")),
+        # groupby_col carries the patrol id (one trajectory per patrol), matching
+        # EarthRangerIO.get_patrol_observations. The leader subject is exposed via
+        # patrol_subject (name) and extra__subject_id (id) rather than groupby_col.
         ("groupby_col", pa.string()),
-        ("extra__subject__name", pa.string()),
-        ("extra__subject__subject_subtype", pa.string()),
+        ("extra__subject_id", pa.string()),
+        ("patrol_subject", pa.string()),
         ("extra__source", pa.string()),
         ("junk_status", pa.bool_()),
         ("patrol_id", pa.string()),

--- a/tests/_fastapi_example.py
+++ b/tests/_fastapi_example.py
@@ -62,19 +62,23 @@ def _patrol_observations_pre_cast(earthranger_rb: pa.RecordBatch) -> pa.RecordBa
     junk_status = pa.array([False] * earthranger_rb.num_rows, type=pa.bool_())
     add_junk_status = earthranger_rb.append_column("junk_status", junk_status)
 
-    # Rename columns to match ECOSCOPE_SLIM_V1 structure and EarthRangerIO field names
+    # Rename columns to match ECOSCOPE_SLIM_V1 structure and EarthRangerIO field names.
+    # The leader subject is surfaced as patrol_subject (name) + extra__subject_id (id),
+    # matching EarthRangerIO.get_patrol_observations; groupby_col carries the patrol id.
     renamed = add_junk_status.rename_columns(
         {
             "location": "geometry",
-            "subject_id": "groupby_col",
+            "subject_id": "extra__subject_id",
             "recorded_at": "fixtime",
-            "subject_name": "extra__subject__name",
-            "subject_subtype_id": "extra__subject__subject_subtype",
+            "subject_name": "patrol_subject",
             "source_id": "extra__source",
             "patrol_type_value": "patrol_type__value",
             "patrol_type_display": "patrol_type__display",
         }
     )
+
+    # groupby_col carries the patrol id so trajectories are grouped one-per-patrol.
+    renamed = renamed.append_column("groupby_col", renamed.column("patrol_id"))
 
     # Add timezone to fixtime (workaround for missing +00:00 in EarthRanger data)
     fixtime_idx = renamed.schema.get_field_index("fixtime")
@@ -85,13 +89,13 @@ def _patrol_observations_pre_cast(earthranger_rb: pa.RecordBatch) -> pa.RecordBa
     result = renamed.drop_columns(["fixtime"])
     result = result.add_column(fixtime_idx, "fixtime", fixtime_utc)
 
-    # Reorder columns to match target schema order
+    # Reorder columns to match target schema order (subject_subtype_id is dropped here)
     target_column_order = [
         "geometry",
         "fixtime",
         "groupby_col",
-        "extra__subject__name",
-        "extra__subject__subject_subtype",
+        "extra__subject_id",
+        "patrol_subject",
         "extra__source",
         "junk_status",
         "patrol_id",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -56,8 +56,10 @@ def _mock_observations_generator(
     if subject_ids is None:
         subject_ids = ["subject1", "subject2"]
 
-    # Mock patrol data for testing
-    mock_patrol_id = str(uuid.uuid4())
+    # Mock patrol data for testing. Each leader subject maps to a distinct
+    # patrol so multi-subject batches exercise one-trajectory-per-patrol
+    # grouping: groupby_col must equal patrol_id (not subject_id).
+    mock_patrol_ids = {sid: f"patrol-{sid}" for sid in subject_ids}
     mock_patrol_serial = 12345
 
     for dt in _split_datetime_range_by_delta(
@@ -92,7 +94,7 @@ def _mock_observations_generator(
             if include_patrol_details:
                 record.update(
                     {
-                        "patrol_id": mock_patrol_id,
+                        "patrol_id": mock_patrol_ids[subject_id],
                         "patrol_title": "Mock Patrol Title",
                         "patrol_serial_number": mock_patrol_serial,
                         "patrol_status": "done",

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -203,7 +203,7 @@ def test_client_get_patrol_observations_with_patrol_filter(
         for col in expected_columns:
             assert col in table.column_names, f"Missing expected column: {col}"
 
-        # ERDW-262: groupby_col must carry the patrol id (one trajectory per
+        # ERDW-264: groupby_col must carry the patrol id (one trajectory per
         # patrol), not the leader subject id, so trajectories aren't collapsed
         # by leader.
         assert (
@@ -215,7 +215,7 @@ def test_client_get_patrol_observations_with_patrol_filter(
         assert len(set(table.column("groupby_col").to_pylist())) == len(
             set(table.column("patrol_id").to_pylist())
         )
-        # ERDW-262: patrol_subject (leader name) must be populated, not null —
+        # ERDW-264: patrol_subject (leader name) must be populated, not null —
         # this is the trajectory-legend color column.
         patrol_subject = table.column("patrol_subject").to_pylist()
         assert all(v == "mock-subject-name" for v in patrol_subject)
@@ -356,7 +356,7 @@ def test_client_get_patrol_observations(app: FastAPI) -> None:
                 f"Missing expected column: {col}"
             )
 
-        # ERDW-262: groupby_col carries patrol id, patrol_subject is populated,
+        # ERDW-264: groupby_col carries patrol id, patrol_subject is populated,
         # and the subject-group leader columns are absent.
         assert (
             observations_table.column("groupby_col").to_pylist()

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -203,6 +203,27 @@ def test_client_get_patrol_observations_with_patrol_filter(
         for col in expected_columns:
             assert col in table.column_names, f"Missing expected column: {col}"
 
+        # ERDW-262: groupby_col must carry the patrol id (one trajectory per
+        # patrol), not the leader subject id, so trajectories aren't collapsed
+        # by leader.
+        assert (
+            table.column("groupby_col").to_pylist()
+            == table.column("patrol_id").to_pylist()
+        )
+        # The fixture maps each leader subject to a distinct patrol, so the
+        # distinct-group count must equal the distinct-patrol count.
+        assert len(set(table.column("groupby_col").to_pylist())) == len(
+            set(table.column("patrol_id").to_pylist())
+        )
+        # ERDW-262: patrol_subject (leader name) must be populated, not null —
+        # this is the trajectory-legend color column.
+        patrol_subject = table.column("patrol_subject").to_pylist()
+        assert all(v == "mock-subject-name" for v in patrol_subject)
+        # The leader-subject columns from the subject-group schema must not
+        # leak into the patrol schema.
+        assert "extra__subject__name" not in table.column_names
+        assert "extra__subject__subject_subtype" not in table.column_names
+
 
 def test_client_get_patrols_minimal(app: FastAPI) -> None:
     """Test the sync get_patrols_minimal method returns PyArrow Table with nested schema."""
@@ -334,6 +355,19 @@ def test_client_get_patrol_observations(app: FastAPI) -> None:
             assert col in observations_table.column_names, (
                 f"Missing expected column: {col}"
             )
+
+        # ERDW-262: groupby_col carries patrol id, patrol_subject is populated,
+        # and the subject-group leader columns are absent.
+        assert (
+            observations_table.column("groupby_col").to_pylist()
+            == observations_table.column("patrol_id").to_pylist()
+        )
+        assert all(
+            v == "mock-subject-name"
+            for v in observations_table.column("patrol_subject").to_pylist()
+        )
+        assert "extra__subject__name" not in observations_table.column_names
+        assert "extra__subject__subject_subtype" not in observations_table.column_names
 
 
 def test_client_query_engine_default_auto(


### PR DESCRIPTION
Aligns the `OBSERVATIONS_WITH_PATROL_SCHEMA_SLIM_V1` arrow schema with `EarthRangerIO.get_patrol_observations`, as consumed by the patrols workflow.

Two bugs are fixed:
  - **Wrong trajectory count** — `groupby_col` carried the patrol *leader subject id*, so the workflow (which groups trajectories by `groupby_col`) collapsed all patrols sharing a leader into one trajectory. `groupby_col` now carries the **patrol id** (one trajectory per patrol).
  - **"None" trajectory legend** — there was no `patrol_subject` column, so the workflow's color/legend column was filled with the literal `"None"`. The schema now includes **`patrol_subject`** (leader name) and **`extra__subject_id`** (leader id).

The old `extra__subject__name` / `extra__subject__subject_subtype` columns are  dropped (they were copied from the subject-tracking obs schema `OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1`, but aren't used for patrol observations analysis).
