### PR TITLE
ERDW-266: Add subject additional field in observation schema

### DIFF
--- a/src/ecoscope_earthranger_io_core/arrow.py
+++ b/src/ecoscope_earthranger_io_core/arrow.py
@@ -20,6 +20,21 @@ OBSERVATIONS_SCHEMA__EARTHRANGER_FULL_V1 = pa.schema(
         ("subject_id", pa.string()),
         ("subject_name", pa.string()),
         ("subject_subtype_id", pa.string()),
+        # Raw `subjects.additional` JSON. EarthRanger declares no schema for it (unlike
+        # event types, which carry an EventType.schema), so it is carried verbatim as a
+        # string and parsed by consumers. Holds the per-subject `rgb` used for track
+        # colouring, plus `sex`/`region`/`country`/`species`.
+        #
+        # NULL means "not requested", and stores must keep it that way:
+        #     include_subject_additional -> COALESCE(s.additional, '{}')
+        #     otherwise                  -> CAST(NULL AS STRING)
+        # The COALESCE is required because the subjects join is a LEFT JOIN (the same
+        # reason the sibling columns use COALESCE(s.name, 'unknown')); a bare
+        # `s.additional` would also yield NULL for observations whose source has no
+        # subjectsource assignment, collapsing "not requested" and "subject
+        # unresolved" into one value. `{}` is safe as the resolved-but-empty marker:
+        # the CDC never writes NULL additional (it coerces to '{}').
+        ("subject_additional", pa.string()),
         ("das_tenant_id", pa.string()),
         ("domain", pa.string()),
         ("observation_id", pa.string()),
@@ -33,6 +48,14 @@ OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1 = pa.schema(
         ("groupby_col", pa.string()),
         ("extra__subject__name", pa.string()),
         ("extra__subject__subject_subtype", pa.string()),
+        # Raw subject `additional` JSON as a string; ecoscope strips the `extra__`
+        # prefix to `subject__additional`, matching the EarthRanger API path where the
+        # nested dict arrives under the same name. Parsed by consumers (e.g.
+        # `assign_subject_colors` reads the `rgb` key) -- EarthRanger declares no
+        # schema for this field, so it is not decomposed into typed columns here.
+        # Always present so the stream schema is stable, but null unless the query
+        # sets `include_subject_additional` (same opt-in shape as `event_details`).
+        ("extra__subject__additional", pa.string()),
         ("extra__source", pa.string()),
         ("junk_status", pa.bool_()),
     ]
@@ -299,6 +322,7 @@ def _observations_pre_cast(earthranger_rb: pa.RecordBatch) -> pa.RecordBatch:
             "source_id": "extra__source",
             "subject_name": "extra__subject__name",
             "subject_subtype_id": "extra__subject__subject_subtype",
+            "subject_additional": "extra__subject__additional",
         }
     )
     # NOTE: workaround for missing +00:00 timezone offset in EarthRanger data, can be removed
@@ -390,6 +414,7 @@ TRANSFORMS: dict[SchemaChoices, TransformSpec] = {
             "source_id",
             "subject_name",
             "subject_subtype_id",
+            "subject_additional",
         ],
         target_schema=OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1,
         pre_cast_fn=_observations_pre_cast,

--- a/src/ecoscope_earthranger_io_core/arrow.py
+++ b/src/ecoscope_earthranger_io_core/arrow.py
@@ -20,20 +20,12 @@ OBSERVATIONS_SCHEMA__EARTHRANGER_FULL_V1 = pa.schema(
         ("subject_id", pa.string()),
         ("subject_name", pa.string()),
         ("subject_subtype_id", pa.string()),
-        # Raw `subjects.additional` JSON. EarthRanger declares no schema for it (unlike
-        # event types, which carry an EventType.schema), so it is carried verbatim as a
-        # string and parsed by consumers. Holds the per-subject `rgb` used for track
-        # colouring, plus `sex`/`region`/`country`/`species`.
-        #
-        # NULL means "not requested", and stores must keep it that way:
-        #     include_subject_additional -> COALESCE(s.additional, '{}')
-        #     otherwise                  -> CAST(NULL AS STRING)
-        # The COALESCE is required because the subjects join is a LEFT JOIN (the same
-        # reason the sibling columns use COALESCE(s.name, 'unknown')); a bare
-        # `s.additional` would also yield NULL for observations whose source has no
-        # subjectsource assignment, collapsing "not requested" and "subject
-        # unresolved" into one value. `{}` is safe as the resolved-but-empty marker:
-        # the CDC never writes NULL additional (it coerces to '{}').
+        # Free-form per-subject JSON, as a string (EarthRanger declares no schema for
+        # it). Holds `rgb` -- used for per-subject track colouring -- plus
+        # `sex`/`region`/`country`/`species`. Values:
+        #     NULL   not requested
+        #     '{}'   requested; the subject has no attributes
+        #     JSON   requested; the subject's attributes
         ("subject_additional", pa.string()),
         ("das_tenant_id", pa.string()),
         ("domain", pa.string()),
@@ -48,13 +40,10 @@ OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1 = pa.schema(
         ("groupby_col", pa.string()),
         ("extra__subject__name", pa.string()),
         ("extra__subject__subject_subtype", pa.string()),
-        # Raw subject `additional` JSON as a string; ecoscope strips the `extra__`
-        # prefix to `subject__additional`, matching the EarthRanger API path where the
-        # nested dict arrives under the same name. Parsed by consumers (e.g.
-        # `assign_subject_colors` reads the `rgb` key) -- EarthRanger declares no
-        # schema for this field, so it is not decomposed into typed columns here.
-        # Always present so the stream schema is stable, but null unless the query
-        # sets `include_subject_additional` (same opt-in shape as `event_details`).
+        # `subject_additional` (see OBSERVATIONS_SCHEMA__EARTHRANGER_FULL_V1). Always
+        # present, but NULL unless the query sets `include_subject_additional`.
+        # ecoscope strips the `extra__` prefix, giving `subject__additional` -- the
+        # same name the EarthRanger API path uses.
         ("extra__subject__additional", pa.string()),
         ("extra__source", pa.string()),
         ("junk_status", pa.bool_()),

--- a/src/ecoscope_earthranger_io_core/client.py
+++ b/src/ecoscope_earthranger_io_core/client.py
@@ -399,6 +399,7 @@ class ERWarehouseClient(BaseModel):
         until: str | None = None,
         query_engine: QueryEngine | None = None,
         filter: int | None = None,
+        include_subject_additional: bool = False,
     ) -> pa.Table:
         """Get observations for a subject group from EarthRanger Data Warehouse.
 
@@ -412,6 +413,10 @@ class ERWarehouseClient(BaseModel):
             until: End of time range (ISO 8601 format).
             query_engine: Backend engine to use. Defaults to the client-level
                 setting (``self.query_engine``).
+            include_subject_additional: Populate the subject ``additional`` JSON in
+                ``extra__subject__additional``. Defaults to False, in which case the
+                column is present but null and the JSON is not read. Opt in only when
+                a consumer needs it (e.g. the ``rgb`` key for per-subject colouring).
 
         Returns:
             PyArrow Table with observations data.
@@ -427,6 +432,7 @@ class ERWarehouseClient(BaseModel):
             range_end=datetime.fromisoformat(until),
             subject_group_name=subject_group_name,
             exclusion_flags=filter,
+            include_subject_additional=include_subject_additional,
         )
         table = self._run_async(
             self._fetch_observations_arrow(query, query_engine=engine)

--- a/src/ecoscope_earthranger_io_core/dataframe.py
+++ b/src/ecoscope_earthranger_io_core/dataframe.py
@@ -36,3 +36,8 @@ class ObservationsGDFSchema(pa.DataFrameModel):
         nullable=True
     )
     extra__subject__sex: pa_typing.Series[str] | None = pa.Field(nullable=True)
+    # Raw subject `additional` JSON as a string. EarthRanger declares no schema for this
+    # field (unlike event types, which carry an EventType.schema), so it is validated as
+    # an opaque string and parsed by consumers -- e.g. ecoscope's `assign_subject_colors`
+    # reads the `rgb` key for per-subject track colouring.
+    extra__subject__additional: pa_typing.Series[str] | None = pa.Field(nullable=True)

--- a/src/ecoscope_earthranger_io_core/query.py
+++ b/src/ecoscope_earthranger_io_core/query.py
@@ -30,6 +30,15 @@ _PATROLS_OVERLAP_DATERANGE_DESCRIPTION = (
 )
 
 
+_INCLUDE_SUBJECT_ADDITIONAL_DESCRIPTION = (
+    "If True, populate the subject `additional` JSON (surfaced as "
+    "`extra__subject__additional`); if False (default), the column is still "
+    "present in the schema but null, and the underlying JSON is not read. "
+    "Opt in only when a consumer needs it -- e.g. per-subject track colouring "
+    "reads the `rgb` key -- since it is a wide, free-form column."
+)
+
+
 class ObservationsQuery(_WarehouseQuery):
     """An EarthRanger observations query.
 
@@ -71,6 +80,10 @@ class ObservationsQuery(_WarehouseQuery):
         description=_PATROLS_OVERLAP_DATERANGE_DESCRIPTION,
     )
     include_patrol_details: bool = False
+    include_subject_additional: bool = Field(
+        default=False,
+        description=_INCLUDE_SUBJECT_ADDITIONAL_DESCRIPTION,
+    )
     exclusion_flags: int | None = Field(
         default=None,
         ge=0,
@@ -93,6 +106,10 @@ class ObservationsQuery(_WarehouseQuery):
         patrol_status: list[PatrolStatus] | None = Query(None),
         patrols_overlap_daterange: bool = Query(True),
         include_patrol_details: bool = Query(False),
+        include_subject_additional: bool = Query(
+            False,
+            description=_INCLUDE_SUBJECT_ADDITIONAL_DESCRIPTION,
+        ),
         exclusion_flags: int | None = Query(
             None,
             ge=0,
@@ -113,6 +130,7 @@ class ObservationsQuery(_WarehouseQuery):
             patrol_status=patrol_status,
             patrols_overlap_daterange=patrols_overlap_daterange,
             include_patrol_details=include_patrol_details,
+            include_subject_additional=include_subject_additional,
             exclusion_flags=exclusion_flags,
         )
 

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -97,27 +97,87 @@ def test_slim_transform_round_trips_subject_additional(subject_additional):
         ("255, 0, 0", (1.0, 0.0, 0.0, 1.0)),  # ecoscope strips whitespace
         ("#FFFF00", None),  # hex is NOT the additional['rgb'] format
         ("not-a-colour", None),
+        (None, None),  # {"rgb": null} -- key present, no value
     ],
 )
-def test_subject_additional_rgb_is_consumable_by_ecoscope(rgb, expected_rgba):
-    """Contract check on the value we transport: after the round trip, the `rgb` key
-    must still parse under ecoscope's rules. Replicates `parse_rgb_str` from
-    ecoscope.platform.tasks.transformation._subjects rather than importing it, since
-    io-core must not depend on ecoscope."""
+def test_documents_earthranger_rgb_format(rgb, expected_rgba):
+    """Executable documentation of the `rgb` format this column transports.
+
+    This asserts nothing about io-core -- the transform is a verbatim passthrough,
+    already pinned by `test_slim_transform_round_trips_subject_additional`. It exists
+    to record which values the downstream consumer can use, mirroring `parse_rgb_str`
+    in ecoscope.platform.tasks.transformation._subjects (copied, not imported: io-core
+    must not depend on ecoscope). If that function changes, this will NOT detect the
+    drift -- the ecoscope side owns that test.
+    """
 
     def parse_rgb_str(rgb_str):
         try:
             r, g, b = [int(x.strip()) for x in rgb_str.split(",")]
             return (r / 255.0, g / 255.0, b / 255.0, 1.0)
-        except (ValueError, AttributeError):
+        except (ValueError, AttributeError, TypeError):
             return None
 
-    transform, rb = _observations_pre_transform_batch(json.dumps({"rgb": rgb}))
+    assert parse_rgb_str(rgb) == expected_rgba
+
+
+@pytest.mark.parametrize(
+    "additional",
+    [
+        pytest.param(json.dumps({"rgb": None}), id="rgb-key-null"),
+        pytest.param(json.dumps({"sex": "female"}), id="no-rgb-key"),
+    ],
+)
+def test_subject_without_a_colour_still_transports(additional):
+    """The common real-world case: a subject has `additional` but no usable colour.
+    io-core must transport it unchanged and leave the fallback decision to the
+    consumer (ecoscope guards with `if rgb_value:`)."""
+    transform, rb = _observations_pre_transform_batch(additional)
 
     out = transform.transform(rb)
-    transported = json.loads(out.column("extra__subject__additional")[0].as_py())
 
-    assert parse_rgb_str(transported["rgb"]) == expected_rgba
+    assert out.column("extra__subject__additional")[0].as_py() == additional
+    assert "rgb" not in json.loads(additional) or json.loads(additional)["rgb"] is None
+
+
+def test_slim_pre_transform_schema_is_the_store_projection_contract():
+    """`pre_transform_schema` is handed to the stores as their SELECT list, and
+    `RecordBatch.cast` is order-sensitive -- so reordering
+    OBSERVATIONS_SCHEMA__EARTHRANGER_FULL_V1 silently breaks the slim cast at request
+    time. Pin the exact projection the stores must emit, in order."""
+    assert TRANSFORMS[SchemaChoices.ECOSCOPE_SLIM_V1].pre_transform_schema.names == [
+        "location",
+        "recorded_at",
+        "subject_id",
+        "subject_name",
+        "subject_subtype_id",
+        "subject_additional",
+        "source_id",
+    ]
+
+
+def test_slim_transform_requires_subject_additional_column():
+    """A store that does not project `subject_additional` must fail loudly rather
+    than silently dropping the column (stores do `batch.select(schema.names)`, so in
+    practice they raise before reaching the transform)."""
+    transform = TRANSFORMS[SchemaChoices.ECOSCOPE_SLIM_V1]
+    without = transform.pre_transform_schema.remove(
+        transform.pre_transform_schema.get_field_index("subject_additional")
+    )
+    rb = pa.record_batch(
+        {
+            "location": ga.array([ga.as_wkb(["POINT (37.5 -2.5)"])[0].wkb]),
+            "recorded_at": ["2015-01-01T00:00:00"],
+            "subject_id": ["subject1"],
+            "subject_name": ["eco_1"],
+            "subject_subtype_id": ["elephant"],
+            "source_id": ["source1"],
+        },
+        schema=without,
+    )
+
+    with pytest.raises(ValueError, match="field names are not matching"):
+        transform.transform(rb)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_arrow.py
+++ b/tests/test_arrow.py
@@ -1,4 +1,5 @@
 import io
+import json
 from datetime import datetime
 
 import geoarrow.pyarrow as ga  # type: ignore[import-untyped]
@@ -19,6 +20,104 @@ def test_slim_schemas_include_extra_source():
     """extra__source must be in the slim schemas so downstream can access it."""
     assert "extra__source" in OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1.names
     assert "extra__source" in OBSERVATIONS_WITH_PATROL_SCHEMA_SLIM_V1.names
+
+
+def test_slim_schema_includes_subject_additional_as_nullable_string():
+    """The subject `additional` JSON is carried verbatim as a string (EarthRanger
+    declares no schema for it). It is always present so the stream schema is stable,
+    and null unless the query sets `include_subject_additional`."""
+    field = OBSERVATIONS_SCHEMA__ECOSCOPE_SLIM_V1.field("extra__subject__additional")
+    assert field.type == pa.string()
+    assert field.nullable
+
+
+def _observations_pre_transform_batch(subject_additional):
+    """One-row batch shaped like the store's SELECT for the ECOSCOPE_SLIM_V1 transform."""
+    transform = TRANSFORMS[SchemaChoices.ECOSCOPE_SLIM_V1]
+    return transform, pa.record_batch(
+        {
+            "location": ga.array([ga.as_wkb(["POINT (37.5 -2.5)"])[0].wkb]),
+            "recorded_at": ["2015-01-01T00:00:00"],
+            "subject_id": ["subject1"],
+            "subject_name": ["eco_1"],
+            "subject_subtype_id": ["elephant"],
+            "subject_additional": [subject_additional],
+            "source_id": ["source1"],
+        },
+        schema=transform.pre_transform_schema,
+    )
+
+
+# A realistic subject `additional` payload. EarthRanger writes `rgb` as a
+# comma-separated decimal triple -- `','.join(str(random.randint(0, 255)) ...)` in
+# das/observations/admin.py, with DEFAULT_COLOR = '255,255,0' -- alongside the keys
+# its serializer flattens (sex/region/country/species) and admin-form extras.
+# NOTE: `rgb` is NOT hex. Hex is only the format of ecoscope's `default_color`
+# parameter, parsed by a different function; a hex value here fails parse_rgb_str
+# and silently falls back to the default colour.
+SUBJECT_ADDITIONAL_JSON = json.dumps(
+    {
+        "rgb": "14,203,87",
+        "sex": "female",
+        "region": "Mara",
+        "country": "Kenya",
+        "species": "elephant",
+        "tm_animal_id": "A-1",
+    }
+)
+
+
+@pytest.mark.parametrize(
+    "subject_additional",
+    [
+        pytest.param(SUBJECT_ADDITIONAL_JSON, id="realistic-payload"),
+        pytest.param(json.dumps({"rgb": "255,255,0"}), id="earthranger-default-color"),
+        pytest.param(json.dumps({"rgb": "255, 0, 0"}), id="whitespace-tolerated"),
+        pytest.param(json.dumps({}), id="empty-additional"),
+        pytest.param(None, id="omitted-null"),
+    ],
+)
+def test_slim_transform_round_trips_subject_additional(subject_additional):
+    """The JSON must survive the transform byte-for-byte, in the same stream schema,
+    for both the opt-in and omitted (null) cases. It is carried verbatim -- no
+    parsing, reformatting, or key filtering happens here."""
+    transform, rb = _observations_pre_transform_batch(subject_additional)
+
+    out = transform.transform(rb)
+
+    assert out.schema.equals(transform.stream_schema)
+    assert out.column("extra__subject__additional")[0].as_py() == subject_additional
+
+
+@pytest.mark.parametrize(
+    "rgb, expected_rgba",
+    [
+        ("14,203,87", (14 / 255.0, 203 / 255.0, 87 / 255.0, 1.0)),
+        ("255,255,0", (1.0, 1.0, 0.0, 1.0)),  # EarthRanger's DEFAULT_COLOR
+        ("255, 0, 0", (1.0, 0.0, 0.0, 1.0)),  # ecoscope strips whitespace
+        ("#FFFF00", None),  # hex is NOT the additional['rgb'] format
+        ("not-a-colour", None),
+    ],
+)
+def test_subject_additional_rgb_is_consumable_by_ecoscope(rgb, expected_rgba):
+    """Contract check on the value we transport: after the round trip, the `rgb` key
+    must still parse under ecoscope's rules. Replicates `parse_rgb_str` from
+    ecoscope.platform.tasks.transformation._subjects rather than importing it, since
+    io-core must not depend on ecoscope."""
+
+    def parse_rgb_str(rgb_str):
+        try:
+            r, g, b = [int(x.strip()) for x in rgb_str.split(",")]
+            return (r / 255.0, g / 255.0, b / 255.0, 1.0)
+        except (ValueError, AttributeError):
+            return None
+
+    transform, rb = _observations_pre_transform_batch(json.dumps({"rgb": rgb}))
+
+    out = transform.transform(rb)
+    transported = json.loads(out.column("extra__subject__additional")[0].as_py())
+
+    assert parse_rgb_str(transported["rgb"]) == expected_rgba
 
 
 @pytest.mark.parametrize(

--- a/tests/test_dataframe.py
+++ b/tests/test_dataframe.py
@@ -53,6 +53,33 @@ def test_observations_gdf_schema_missing_column_raises():
         ObservationsGDFSchema.validate(gdf)
 
 
+@pytest.mark.parametrize(
+    "additional",
+    [
+        pytest.param(['{"rgb": "14,203,87"}', '{"rgb": "255,0,0"}'], id="populated"),
+        pytest.param([None, None], id="all-null-not-requested"),
+        pytest.param(['{"rgb": "14,203,87"}', None], id="mixed"),
+    ],
+)
+def test_observations_gdf_schema_accepts_subject_additional(additional):
+    """`extra__subject__additional` is optional and nullable: it is always present in
+    the slim arrow schema but null unless the query sets `include_subject_additional`,
+    so validation must pass for populated, all-null, and mixed columns alike."""
+    gdf = gpd.GeoDataFrame(
+        {
+            "geometry": [Point((0, 0)), Point((0, 1))],
+            "groupby_col": ["subject1", "subject1"],
+            "fixtime": [
+                dt.datetime.fromisoformat("2023-01-01T00:00:00+00:00"),
+                dt.datetime.fromisoformat("2023-01-02T00:00:00+00:00"),
+            ],
+            "junk_status": [False, False],
+            "extra__subject__additional": additional,
+        }
+    )
+    ObservationsGDFSchema.validate(gdf, lazy=True)
+
+
 def test_observations_from_arrow():
     query = ObservationsQuery(
         tenant_domain="some-site.pamdas.org",

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -35,6 +35,7 @@ def test_observations_query_from_query_params_round_trip(value):
         patrol_status=None,
         patrols_overlap_daterange=True,
         include_patrol_details=False,
+        include_subject_additional=False,
         exclusion_flags=value,
     )
     assert q.exclusion_flags == value
@@ -75,9 +76,49 @@ def test_observations_query_from_query_params_patrols_overlap_daterange(value):
         patrol_status=None,
         patrols_overlap_daterange=value,
         include_patrol_details=False,
+        include_subject_additional=False,
         exclusion_flags=None,
     )
     assert q.patrols_overlap_daterange is value
+
+
+def test_observations_query_include_subject_additional_default_is_false():
+    """Opt-in: the subject `additional` JSON is a wide free-form column, so it is
+    only populated when a consumer asks for it (e.g. `rgb` for track colouring)."""
+    q = ObservationsQuery(tenant_domain="example.pamdas.org")
+    assert q.include_subject_additional is False
+    assert q.model_dump()["include_subject_additional"] is False
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_observations_query_include_subject_additional_round_trip(value):
+    q = ObservationsQuery(
+        tenant_domain="example.pamdas.org", include_subject_additional=value
+    )
+    assert q.include_subject_additional is value
+    assert q.model_dump()["include_subject_additional"] is value
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_observations_query_from_query_params_include_subject_additional(value):
+    # ``from_query_params`` is a FastAPI dependency; when called directly
+    # we must pass every parameter explicitly so the ``Query(...)``
+    # sentinels don't leak into pydantic.
+    q = ObservationsQuery.from_query_params(
+        tenant_domain="example.pamdas.org",
+        range_start=None,
+        range_end=None,
+        subject_ids=None,
+        subject_group_name=None,
+        patrol_ids=None,
+        patrol_type_value=None,
+        patrol_status=None,
+        patrols_overlap_daterange=True,
+        include_patrol_details=False,
+        include_subject_additional=value,
+        exclusion_flags=None,
+    )
+    assert q.include_subject_additional is value
 
 
 def test_patrols_query_patrols_overlap_daterange_default_is_true():


### PR DESCRIPTION
Adds per-subject additional field as `extra__subject__additional`, so that consumers can read the `rgb` key for per-subject track coloring. The column is always present to keep the stream schema stable but null unless `include_subject_additional` is set, so workflows that don't need it pay nothing.

There will be follow-up PR in the API to return the subject additional data conditioned to `include_subject_additional` query param.