### PR TITLE
ERDW-269: Request data via POST /search to support larger filters

### DIFF
--- a/src/ecoscope_earthranger_io_core/client.py
+++ b/src/ecoscope_earthranger_io_core/client.py
@@ -743,7 +743,12 @@ class ERWarehouseClient(BaseModel):
 
         query = ObservationsQuery(
             tenant_domain=self.server,
-            patrol_ids=list(set(patrol_ids)),
+            # ``or None`` so an empty patrols_df sends no patrol_ids at all.
+            # ``exclude_none`` drops None but keeps [], and a JSON body carries
+            # the empty list through where a query string dropped it -- an
+            # explicit [] that a server did not normalize back to None would
+            # read as "no patrol filter" and scan the whole tenant.
+            patrol_ids=list(set(patrol_ids)) or None,
             include_patrol_details=include_patrol_details,
             exclusion_flags=filter,
         )

--- a/src/ecoscope_earthranger_io_core/client.py
+++ b/src/ecoscope_earthranger_io_core/client.py
@@ -72,6 +72,73 @@ async def _get_table(
     return table
 
 
+async def _search_table(
+    client: httpx.AsyncClient,
+    route: str,
+    query: BaseModel,
+    headers: dict[str, str] | None = None,
+    store_type: QueryEngine | None = None,
+    extra_params: dict | None = None,
+) -> pa.Table:
+    """Read an Arrow IPC stream from a warehouse ``/search`` route.
+
+    Like :func:`_get_table`, this fetches data and returns it as a PyArrow
+    Table -- despite issuing a POST, nothing is created or mutated. The
+    warehouse exposes these reads as POST because the filters travel in a JSON
+    body rather than the query string, and a GET body is not routable.
+
+    Sending filters in the body means the ones that grow with the result set
+    (``patrol_ids``, ``subject_ids``) are no longer bounded by URL length:
+    httpx refuses to build a request whose query component exceeds 65536
+    chars, and the load balancer caps the request line well below that --
+    around 1365 patrol UUIDs the request used to fail client-side, before it
+    ever reached the API.
+
+    Response-shaping options (``store_type`` and anything in ``extra_params``)
+    stay in the query string, matching the API's ``/search`` routes.
+
+    Args:
+        client: The httpx async client.
+        route: The API route to call.
+        query: A Pydantic model specifying the query filters (sent as the body).
+        headers: Optional headers to include.
+        store_type: Optional store type to pass as a query parameter
+            (maps to the DWH API's ``store_type`` param).
+        extra_params: Optional response-shaping flags merged into the query
+            string after ``store_type``.
+    """
+    params: dict = {}
+    if store_type is not None:
+        params["store_type"] = store_type
+    if extra_params:
+        params.update(extra_params)
+    # mode="json" so datetime fields serialize to ISO strings; the plain dump
+    # leaves datetime objects that json= cannot encode.
+    body = query.model_dump(mode="json", exclude_none=True)
+    async with client.stream(
+        "POST",
+        route,
+        json=body,
+        params=params,
+        headers=headers,
+        timeout=600,
+    ) as response:
+        response.raise_for_status()
+        sink = io.BytesIO()
+        async for chunk in response.aiter_bytes():
+            sink.write(chunk)
+        sink.seek(0)
+    source = sink.getvalue()
+    if not source:
+        raise ConnectionError(
+            f"Warehouse API stream broke for {route}: "
+            "received an empty response. The API may have crashed or "
+            "the connection was closed unexpectedly."
+        )
+    table = pa.ipc.open_stream(source).read_all()
+    return table
+
+
 class ERWarehouseClient(BaseModel):
     """EarthRanger Warehouse Client.
 
@@ -277,9 +344,9 @@ class ERWarehouseClient(BaseModel):
     ) -> pa.Table:
         """Internal async method to fetch observations as Arrow table."""
         async with self._httpx_client() as client:
-            table = await _get_table(
+            table = await _search_table(
                 client=client,
-                route=f"{self.warehouse_observations_endpoint}/stream/arrow",
+                route=f"{self.warehouse_observations_endpoint}/search/stream/arrow",
                 query=query,
                 headers=self._get_auth_headers(),
                 store_type=query_engine,
@@ -293,9 +360,9 @@ class ERWarehouseClient(BaseModel):
     ) -> pa.Table:
         """Internal async method to fetch patrols as Arrow table."""
         async with self._httpx_client() as client:
-            table = await _get_table(
+            table = await _search_table(
                 client=client,
-                route=f"{self.warehouse_patrols_endpoint}/stream/arrow",
+                route=f"{self.warehouse_patrols_endpoint}/search/stream/arrow",
                 query=query,
                 headers=self._get_auth_headers(),
                 store_type=query_engine,
@@ -309,9 +376,9 @@ class ERWarehouseClient(BaseModel):
     ) -> pa.Table:
         """Internal async method to fetch events as Arrow table."""
         async with self._httpx_client() as client:
-            table = await _get_table(
+            table = await _search_table(
                 client=client,
-                route=f"{self.warehouse_events_endpoint}/stream/arrow",
+                route=f"{self.warehouse_events_endpoint}/search/stream/arrow",
                 query=query,
                 headers=self._get_auth_headers(),
                 store_type=query_engine,

--- a/tests/_fastapi_example.py
+++ b/tests/_fastapi_example.py
@@ -158,6 +158,25 @@ async def get_observations_streaming_arrow(
         raise HTTPException(status_code=500, detail=f"Failed to read data: {str(e)}")
 
 
+@observations.post("/search/stream/arrow")
+async def search_observations_streaming_arrow(
+    query: ObservationsQuery,
+    schema: SchemaChoices = Query(
+        "ECOSCOPE_SLIM_V1",
+        description="Schema to use for the response",
+    ),
+    store_type: QueryEngine | None = Query(None),
+):
+    """POST twin of the GET route: filters arrive as a JSON body.
+
+    Mirrors the real API, where the body binds the query model and the
+    response-shaping options stay in the query string.
+    """
+    return await get_observations_streaming_arrow(
+        query=query, schema=schema, store_type=store_type
+    )
+
+
 app.include_router(observations)
 
 # Patrols router
@@ -252,6 +271,15 @@ async def get_patrols_streaming_arrow(
         raise HTTPException(status_code=500, detail=f"Failed to read data: {str(e)}")
 
 
+@patrols.post("/search/stream/arrow")
+async def search_patrols_streaming_arrow(
+    query: PatrolsQuery,
+    store_type: QueryEngine | None = Query(None),
+):
+    """POST twin of the GET route: filters arrive as a JSON body."""
+    return await get_patrols_streaming_arrow(query=query, store_type=store_type)
+
+
 app.include_router(patrols)
 
 # Events router
@@ -336,6 +364,15 @@ async def get_events_streaming_arrow(
         )
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Failed to read data: {str(e)}")
+
+
+@events.post("/search/stream/arrow")
+async def search_events_streaming_arrow(
+    query: EventsQuery,
+    store_type: QueryEngine | None = Query(None),
+):
+    """POST twin of the GET route: filters arrive as a JSON body."""
+    return await get_events_streaming_arrow(query=query, store_type=store_type)
 
 
 def _canned_event_details_struct(parse_detail_datetimes: bool) -> pa.StructType:

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,7 +1,9 @@
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
 from typing import AsyncIterable, Callable
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
 
 from pydantic import SecretStr
 
@@ -18,7 +20,11 @@ from ecoscope_earthranger_io_core.arrow import (
     PATROLS_NESTED_SCHEMA_V1,
     PATROLS_WITH_EVENTS_NESTED_SCHEMA_V1,
 )
-from ecoscope_earthranger_io_core.client import ERWarehouseClient, _get_table
+from ecoscope_earthranger_io_core.client import (
+    ERWarehouseClient,
+    _get_table,
+    _search_table,
+)
 from ecoscope_earthranger_io_core.query import ObservationsQuery
 
 from _fastapi_example import app as _app
@@ -124,6 +130,17 @@ async def test__get_table_raises_on_empty_stream() -> None:
                 route="/observations/stream/arrow",
                 query=query,
             )
+
+
+def _sent(captured: dict) -> dict:
+    """Everything the client put on the wire, body and query string merged.
+
+    Filters now travel in the JSON body of the POST /search routes while
+    response-shaping options (store_type) stay in the query string. These
+    tests assert *that* a flag was forwarded; the dedicated transport tests
+    below assert *where* it was forwarded.
+    """
+    return {**(captured.get("query_params") or {}), **(captured.get("body") or {})}
 
 
 def test_client_get_subjectgroup_observations(
@@ -397,15 +414,15 @@ def test_client_query_engine_default_auto(
         )
         assert er_client.query_engine == "auto"
 
-        original_get_table = _get_table
+        original_search_table = _search_table
 
-        async def _capturing_get_table(*args, **kwargs):
+        async def _capturing_search_table(*args, **kwargs):
             captured_params["store_type"] = kwargs.get("store_type")
-            return await original_get_table(*args, **kwargs)
+            return await original_search_table(*args, **kwargs)
 
         with patch(
-            "ecoscope_earthranger_io_core.client._get_table",
-            side_effect=_capturing_get_table,
+            "ecoscope_earthranger_io_core.client._search_table",
+            side_effect=_capturing_search_table,
         ):
             table = er_client.get_subjectgroup_observations(
                 subject_group_name="Ecoscope",
@@ -442,15 +459,15 @@ def test_client_query_engine_explicit_per_request(
             warehouse_base_url="http://test",
         )
 
-        original_get_table = _get_table
+        original_search_table = _search_table
 
-        async def _capturing_get_table(*args, **kwargs):
+        async def _capturing_search_table(*args, **kwargs):
             captured_params["store_type"] = kwargs.get("store_type")
-            return await original_get_table(*args, **kwargs)
+            return await original_search_table(*args, **kwargs)
 
         with patch(
-            "ecoscope_earthranger_io_core.client._get_table",
-            side_effect=_capturing_get_table,
+            "ecoscope_earthranger_io_core.client._search_table",
+            side_effect=_capturing_search_table,
         ):
             table = er_client.get_subjectgroup_observations(
                 subject_group_name="Ecoscope",
@@ -489,15 +506,15 @@ def test_client_query_engine_client_level_default(
             query_engine="iceberg-dd",
         )
 
-        original_get_table = _get_table
+        original_search_table = _search_table
 
-        async def _capturing_get_table(*args, **kwargs):
+        async def _capturing_search_table(*args, **kwargs):
             captured_params["store_type"] = kwargs.get("store_type")
-            return await original_get_table(*args, **kwargs)
+            return await original_search_table(*args, **kwargs)
 
         with patch(
-            "ecoscope_earthranger_io_core.client._get_table",
-            side_effect=_capturing_get_table,
+            "ecoscope_earthranger_io_core.client._search_table",
+            side_effect=_capturing_search_table,
         ):
             table = er_client.get_subjectgroup_observations(
                 subject_group_name="Ecoscope",
@@ -535,15 +552,15 @@ def test_client_query_engine_per_request_overrides_client_default(
             query_engine="iceberg-dd",
         )
 
-        original_get_table = _get_table
+        original_search_table = _search_table
 
-        async def _capturing_get_table(*args, **kwargs):
+        async def _capturing_search_table(*args, **kwargs):
             captured_params["store_type"] = kwargs.get("store_type")
-            return await original_get_table(*args, **kwargs)
+            return await original_search_table(*args, **kwargs)
 
         with patch(
-            "ecoscope_earthranger_io_core.client._get_table",
-            side_effect=_capturing_get_table,
+            "ecoscope_earthranger_io_core.client._search_table",
+            side_effect=_capturing_search_table,
         ):
             table = er_client.get_subjectgroup_observations(
                 subject_group_name="Ecoscope",
@@ -640,7 +657,10 @@ def _capturing_mock_httpx_client(app: FastAPI, captured: dict):
             original_stream = mock_httpx_client.stream
 
             def _capturing_stream(method, url, **kwargs):
-                captured["params"] = kwargs.get("params")
+                captured["method"] = method
+                captured["url"] = url
+                captured["query_params"] = kwargs.get("params")
+                captured["body"] = kwargs.get("json")
                 return original_stream(method, url, **kwargs)
 
             mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
@@ -689,7 +709,10 @@ def test_client_get_events_raw_multi_type(app: FastAPI) -> None:
             original_stream = mock_httpx_client.stream
 
             def _capturing_stream(method, url, **kwargs):
-                captured["params"] = kwargs.get("params")
+                captured["method"] = method
+                captured["url"] = url
+                captured["query_params"] = kwargs.get("params")
+                captured["body"] = kwargs.get("json")
                 return original_stream(method, url, **kwargs)
 
             mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
@@ -709,9 +732,9 @@ def test_client_get_events_raw_multi_type(app: FastAPI) -> None:
         )
     assert isinstance(table, pa.Table)
     assert len(table) > 0
-    assert captured["params"]["raw_details"] is True
+    assert _sent(captured)["raw_details"] is True
     # raw details are still details, so the payload is included
-    assert captured["params"]["include_details"] is True
+    assert _sent(captured)["include_details"] is True
 
 
 def test_client_get_events_no_details_default(app: FastAPI) -> None:
@@ -731,8 +754,8 @@ def test_client_get_events_no_details_default(app: FastAPI) -> None:
             until="2015-03-01T00:00:00",
             event_type=["a", "b"],
         )
-    assert captured["params"]["include_details"] is False
-    assert captured["params"]["raw_details"] is False
+    assert _sent(captured)["include_details"] is False
+    assert _sent(captured)["raw_details"] is False
 
 
 def test_client_get_events_typed_path_params(app: FastAPI) -> None:
@@ -752,8 +775,8 @@ def test_client_get_events_typed_path_params(app: FastAPI) -> None:
             event_type=["wildlife_sighting"],
             include_details=True,
         )
-    assert captured["params"]["include_details"] is True
-    assert captured["params"]["raw_details"] is False
+    assert _sent(captured)["include_details"] is True
+    assert _sent(captured)["raw_details"] is False
 
     captured.clear()
     with patch.object(
@@ -771,9 +794,9 @@ def test_client_get_events_typed_path_params(app: FastAPI) -> None:
             parse_detail_datetimes=True,
             invalid_only=True,
         )
-    assert captured["params"]["raw_details"] is False
-    assert captured["params"]["parse_detail_datetimes"] is True
-    assert captured["params"]["invalid_only"] is True
+    assert _sent(captured)["raw_details"] is False
+    assert _sent(captured)["parse_detail_datetimes"] is True
+    assert _sent(captured)["invalid_only"] is True
 
 
 def test_client_get_events_optional_time_range(app: FastAPI) -> None:
@@ -792,8 +815,8 @@ def test_client_get_events_optional_time_range(app: FastAPI) -> None:
         # no since/until at all
         table = er_client.get_events(event_type=["wildlife_sighting"])
     assert isinstance(table, pa.Table)
-    assert "range_start" not in captured["params"]
-    assert "range_end" not in captured["params"]
+    assert "range_start" not in _sent(captured)
+    assert "range_end" not in _sent(captured)
 
     # half-bounded (only since) is allowed too
     captured.clear()
@@ -806,8 +829,8 @@ def test_client_get_events_optional_time_range(app: FastAPI) -> None:
             warehouse_base_url="http://test",
         )
         er_client.get_events(since="2015-01-01T00:00:00", event_type=["a", "b"])
-    assert "range_start" in captured["params"]
-    assert "range_end" not in captured["params"]
+    assert "range_start" in _sent(captured)
+    assert "range_end" not in _sent(captured)
 
 
 def test_client_get_events_forwards_invalid_details(app: FastAPI) -> None:
@@ -828,7 +851,7 @@ def test_client_get_events_forwards_invalid_details(app: FastAPI) -> None:
             include_details=True,
             invalid_details="coerce",
         )
-    assert captured["params"]["invalid_details"] == "coerce"
+    assert _sent(captured)["invalid_details"] == "coerce"
 
 
 def test_client_get_events_rejects_unsupported() -> None:
@@ -919,8 +942,8 @@ def test_client_get_events_include_and_raw_details_compose(app: FastAPI) -> None
             include_details=True,
             raw_details=True,
         )
-    assert captured["params"]["raw_details"] is True
-    assert captured["params"]["include_details"] is True
+    assert _sent(captured)["raw_details"] is True
+    assert _sent(captured)["include_details"] is True
 
 
 def test_client_get_events_invalid_details_triggers_typed_mode(app: FastAPI) -> None:
@@ -941,9 +964,9 @@ def test_client_get_events_invalid_details_triggers_typed_mode(app: FastAPI) -> 
             event_type=["wildlife_sighting"],
             invalid_details="drop",
         )
-    assert captured["params"]["invalid_details"] == "drop"
-    assert captured["params"]["raw_details"] is False
-    assert captured["params"]["include_details"] is True
+    assert _sent(captured)["invalid_details"] == "drop"
+    assert _sent(captured)["raw_details"] is False
+    assert _sent(captured)["include_details"] is True
 
 
 def test_client_get_event_types(app: FastAPI) -> None:
@@ -1211,7 +1234,10 @@ def test_client_get_subjectgroup_observations_forwards_exclusion_flags(
             original_stream = mock_httpx_client.stream
 
             def _capturing_stream(method, url, **kwargs):
-                captured["params"] = kwargs.get("params")
+                captured["method"] = method
+                captured["url"] = url
+                captured["query_params"] = kwargs.get("params")
+                captured["body"] = kwargs.get("json")
                 return original_stream(method, url, **kwargs)
 
             mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
@@ -1234,7 +1260,7 @@ def test_client_get_subjectgroup_observations_forwards_exclusion_flags(
             filter=value,
         )
 
-    params = captured["params"]
+    params = _sent(captured)
     if value is None:
         assert "exclusion_flags" not in params
     else:
@@ -1258,7 +1284,10 @@ def test_client_get_patrol_observations_with_patrol_filter_forwards_exclusion_fl
             original_stream = mock_httpx_client.stream
 
             def _capturing_stream(method, url, **kwargs):
-                captured["params"] = kwargs.get("params")
+                captured["method"] = method
+                captured["url"] = url
+                captured["query_params"] = kwargs.get("params")
+                captured["body"] = kwargs.get("json")
                 return original_stream(method, url, **kwargs)
 
             mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
@@ -1283,7 +1312,7 @@ def test_client_get_patrol_observations_with_patrol_filter_forwards_exclusion_fl
             filter=value,
         )
 
-    params = captured["params"]
+    params = _sent(captured)
     if value is None:
         assert "exclusion_flags" not in params
     else:
@@ -1312,7 +1341,10 @@ def test_client_get_patrol_observations_with_patrol_filter_forwards_patrols_over
             original_stream = mock_httpx_client.stream
 
             def _capturing_stream(method, url, **kwargs):
-                captured["params"] = kwargs.get("params")
+                captured["method"] = method
+                captured["url"] = url
+                captured["query_params"] = kwargs.get("params")
+                captured["body"] = kwargs.get("json")
                 return original_stream(method, url, **kwargs)
 
             mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
@@ -1337,7 +1369,7 @@ def test_client_get_patrol_observations_with_patrol_filter_forwards_patrols_over
             include_patrol_details=True,
         )
 
-    params = captured["params"]
+    params = _sent(captured)
     assert params["patrols_overlap_daterange"] == value
 
 
@@ -1356,7 +1388,10 @@ def test_client_get_patrol_observations_with_patrol_filter_default_patrols_overl
             original_stream = mock_httpx_client.stream
 
             def _capturing_stream(method, url, **kwargs):
-                captured["params"] = kwargs.get("params")
+                captured["method"] = method
+                captured["url"] = url
+                captured["query_params"] = kwargs.get("params")
+                captured["body"] = kwargs.get("json")
                 return original_stream(method, url, **kwargs)
 
             mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
@@ -1380,7 +1415,7 @@ def test_client_get_patrol_observations_with_patrol_filter_default_patrols_overl
             include_patrol_details=True,
         )
 
-    params = captured["params"]
+    params = _sent(captured)
     assert params["patrols_overlap_daterange"] is True
 
 
@@ -1401,7 +1436,10 @@ def test_client_get_patrols_minimal_forwards_patrols_overlap_daterange(
             original_stream = mock_httpx_client.stream
 
             def _capturing_stream(method, url, **kwargs):
-                captured["params"] = kwargs.get("params")
+                captured["method"] = method
+                captured["url"] = url
+                captured["query_params"] = kwargs.get("params")
+                captured["body"] = kwargs.get("json")
                 return original_stream(method, url, **kwargs)
 
             mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
@@ -1425,7 +1463,7 @@ def test_client_get_patrols_minimal_forwards_patrols_overlap_daterange(
             patrols_overlap_daterange=value,
         )
 
-    params = captured["params"]
+    params = _sent(captured)
     assert params["patrols_overlap_daterange"] == value
 
 
@@ -1444,7 +1482,10 @@ def test_client_get_patrols_minimal_default_patrols_overlap_daterange_is_true(
             original_stream = mock_httpx_client.stream
 
             def _capturing_stream(method, url, **kwargs):
-                captured["params"] = kwargs.get("params")
+                captured["method"] = method
+                captured["url"] = url
+                captured["query_params"] = kwargs.get("params")
+                captured["body"] = kwargs.get("json")
                 return original_stream(method, url, **kwargs)
 
             mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
@@ -1467,5 +1508,128 @@ def test_client_get_patrols_minimal_default_patrols_overlap_daterange_is_true(
             status=["done"],
         )
 
-    params = captured["params"]
+    params = _sent(captured)
     assert params["patrols_overlap_daterange"] is True
+
+
+# -------------------------------------------------------------------------
+# POST /search transport tests (ERDW-269)
+# -------------------------------------------------------------------------
+
+
+@contextmanager
+def _capture_request(app: FastAPI, captured: dict):
+    """Patch the client's httpx factory and record what goes on the wire."""
+
+    @asynccontextmanager
+    async def _mock_httpx_client(self):
+        async with AsyncClient(
+            transport=ASGITransport(app),
+            base_url="http://test",
+        ) as mock_httpx_client:
+            original_stream = mock_httpx_client.stream
+
+            def _capturing_stream(method, url, **kwargs):
+                captured["method"] = method
+                captured["url"] = url
+                captured["query_params"] = kwargs.get("params")
+                captured["body"] = kwargs.get("json")
+                return original_stream(method, url, **kwargs)
+
+            mock_httpx_client.stream = _capturing_stream  # type: ignore[assignment]
+            yield mock_httpx_client
+
+    with patch.object(ERWarehouseClient, "_httpx_client", _mock_httpx_client):
+        yield
+
+
+def _client() -> ERWarehouseClient:
+    return ERWarehouseClient(
+        server="some-site.pamdas.org",
+        token="abc",
+        warehouse_base_url="http://test",
+    )
+
+
+def test_observations_filters_travel_in_the_body_not_the_url(app: FastAPI) -> None:
+    """Filters must not reach the query string, or the URL-length bug returns."""
+    captured: dict = {}
+    with _capture_request(app, captured):
+        _client().get_subjectgroup_observations(
+            subject_group_name="Ecoscope",
+            since="2015-01-01T12:00:00",
+            until="2015-03-01T12:00:00",
+        )
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "/observations/search/stream/arrow"
+    body = captured["body"]
+    assert body["subject_group_name"] == "Ecoscope"
+    assert body["range_start"] == "2015-01-01T12:00:00"
+    assert body["tenant_domain"] == "some-site.pamdas.org"
+    # Response shaping stays in the query string; filters must not appear there.
+    assert captured["query_params"] == {"store_type": "auto"}
+
+
+def test_patrols_filters_travel_in_the_body_not_the_url(app: FastAPI) -> None:
+    captured: dict = {}
+    with _capture_request(app, captured):
+        _client().get_patrols_minimal(
+            since="2015-01-01T12:00:00",
+            until="2015-03-01T12:00:00",
+            patrol_type_value=["routine_patrol"],
+            status=["done"],
+        )
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "/patrols/search/stream/arrow"
+    body = captured["body"]
+    assert body["patrol_type_value"] == ["routine_patrol"]
+    assert body["patrol_status"] == ["done"]
+    assert captured["query_params"] == {"store_type": "auto"}
+
+
+def test_events_filters_travel_in_the_body_not_the_url(app: FastAPI) -> None:
+    captured: dict = {}
+    with _capture_request(app, captured):
+        _client().get_events(
+            since="2015-01-01T12:00:00",
+            until="2015-03-01T12:00:00",
+            event_type=["wildlife_sighting"],
+        )
+
+    assert captured["method"] == "POST"
+    assert captured["url"] == "/events/search/stream/arrow"
+    assert captured["body"]["event_type"] == ["wildlife_sighting"]
+    assert captured["query_params"] == {"store_type": "auto"}
+
+
+def test_patrol_ids_list_too_long_for_a_url_is_sent_and_applied(
+    app: FastAPI,
+) -> None:
+    """The regression this change exists for.
+
+    ~1365 patrol UUIDs used to overflow httpx's 65536-char URL component limit
+    and raise InvalidURL before the request left the process. In a JSON body
+    there is no such ceiling, and the whole list must arrive intact -- a
+    silently dropped patrol filter would return every patrol in the tenant.
+    """
+    import uuid
+
+    patrol_ids = [str(uuid.uuid4()) for _ in range(2000)]
+    captured: dict = {}
+    with _capture_request(app, captured):
+        table = _client().get_patrol_observations(
+            patrols_df=pa.table({"id": pa.array(patrol_ids, type=pa.string())}),
+        )
+
+    assert isinstance(table, pa.Table)
+    assert captured["method"] == "POST"
+    assert sorted(captured["body"]["patrol_ids"]) == sorted(patrol_ids)
+    # The same list as a query string would exceed httpx's limit outright.
+    with pytest.raises(httpx.InvalidURL):
+        httpx.Request(
+            "GET",
+            "http://test/observations/stream/arrow",
+            params={"patrol_ids": patrol_ids},
+        )

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,3 +1,5 @@
+import io
+import json
 from contextlib import asynccontextmanager, contextmanager
 from datetime import datetime
 from typing import AsyncIterable, Callable
@@ -132,15 +134,88 @@ async def test__get_table_raises_on_empty_stream() -> None:
             )
 
 
-def _sent(captured: dict) -> dict:
-    """Everything the client put on the wire, body and query string merged.
+@pytest.mark.asyncio
+async def test__search_table_raises_on_empty_stream() -> None:
+    """Same guard as the GET helper, on the path that now serves the reads.
 
-    Filters now travel in the JSON body of the POST /search routes while
-    response-shaping options (store_type) stay in the query string. These
-    tests assert *that* a flag was forwarded; the dedicated transport tests
-    below assert *where* it was forwarded.
+    All three Arrow endpoints go through ``_search_table``; ``_get_table``
+    only serves ``/event_types``. An empty body must surface as a clear
+    ConnectionError rather than a pyarrow parse error.
     """
-    return {**(captured.get("query_params") or {}), **(captured.get("body") or {})}
+    query = ObservationsQuery(
+        tenant_domain="some-site.pamdas.org",
+        subject_ids=["subject1"],
+        range_start=datetime(2023, 1, 1),
+        range_end=datetime(2023, 12, 31),
+    )
+
+    async def empty_response(scope, receive, send):
+        assert scope["method"] == "POST"
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": b""})
+
+    async with AsyncClient(
+        transport=ASGITransport(empty_response),
+        base_url="http://test",
+    ) as client:
+        with pytest.raises(ConnectionError, match="stream broke"):
+            await _search_table(
+                client=client,
+                route="/observations/search/stream/arrow",
+                query=query,
+            )
+
+
+@pytest.mark.asyncio
+async def test__search_table_returns_table_and_sends_filters_in_the_body() -> None:
+    """Success path for the helper, plus proof the body is what carries filters."""
+    seen: dict = {}
+
+    async def echo_app(scope, receive, send):
+        body = b""
+        while True:
+            message = await receive()
+            body += message.get("body", b"")
+            if not message.get("more_body"):
+                break
+        seen["method"] = scope["method"]
+        seen["path"] = scope["path"]
+        seen["query_string"] = scope["query_string"].decode()
+        seen["body"] = json.loads(body)
+
+        sink = io.BytesIO()
+        table = pa.table({"a": pa.array([1, 2, 3], type=pa.int64())})
+        with pa.ipc.new_stream(sink, table.schema) as writer:
+            writer.write_table(table)
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        await send({"type": "http.response.body", "body": sink.getvalue()})
+
+    query = ObservationsQuery(
+        tenant_domain="some-site.pamdas.org",
+        subject_ids=["subject1"],
+        range_start=datetime(2023, 1, 1),
+        range_end=datetime(2023, 12, 31),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(echo_app),
+        base_url="http://test",
+    ) as client:
+        table = await _search_table(
+            client=client,
+            route="/observations/search/stream/arrow",
+            query=query,
+            store_type="iceberg-dd",
+        )
+
+    assert isinstance(table, pa.Table)
+    assert table.num_rows == 3
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/observations/search/stream/arrow"
+    assert seen["body"]["subject_ids"] == ["subject1"]
+    assert seen["body"]["range_start"] == "2023-01-01T00:00:00"
+    # Only response shaping belongs in the URL.
+    assert seen["query_string"] == "store_type=iceberg-dd"
 
 
 def test_client_get_subjectgroup_observations(
@@ -732,9 +807,9 @@ def test_client_get_events_raw_multi_type(app: FastAPI) -> None:
         )
     assert isinstance(table, pa.Table)
     assert len(table) > 0
-    assert _sent(captured)["raw_details"] is True
+    assert captured["body"]["raw_details"] is True
     # raw details are still details, so the payload is included
-    assert _sent(captured)["include_details"] is True
+    assert captured["body"]["include_details"] is True
 
 
 def test_client_get_events_no_details_default(app: FastAPI) -> None:
@@ -754,8 +829,8 @@ def test_client_get_events_no_details_default(app: FastAPI) -> None:
             until="2015-03-01T00:00:00",
             event_type=["a", "b"],
         )
-    assert _sent(captured)["include_details"] is False
-    assert _sent(captured)["raw_details"] is False
+    assert captured["body"]["include_details"] is False
+    assert captured["body"]["raw_details"] is False
 
 
 def test_client_get_events_typed_path_params(app: FastAPI) -> None:
@@ -775,8 +850,8 @@ def test_client_get_events_typed_path_params(app: FastAPI) -> None:
             event_type=["wildlife_sighting"],
             include_details=True,
         )
-    assert _sent(captured)["include_details"] is True
-    assert _sent(captured)["raw_details"] is False
+    assert captured["body"]["include_details"] is True
+    assert captured["body"]["raw_details"] is False
 
     captured.clear()
     with patch.object(
@@ -794,9 +869,9 @@ def test_client_get_events_typed_path_params(app: FastAPI) -> None:
             parse_detail_datetimes=True,
             invalid_only=True,
         )
-    assert _sent(captured)["raw_details"] is False
-    assert _sent(captured)["parse_detail_datetimes"] is True
-    assert _sent(captured)["invalid_only"] is True
+    assert captured["body"]["raw_details"] is False
+    assert captured["body"]["parse_detail_datetimes"] is True
+    assert captured["body"]["invalid_only"] is True
 
 
 def test_client_get_events_optional_time_range(app: FastAPI) -> None:
@@ -815,8 +890,8 @@ def test_client_get_events_optional_time_range(app: FastAPI) -> None:
         # no since/until at all
         table = er_client.get_events(event_type=["wildlife_sighting"])
     assert isinstance(table, pa.Table)
-    assert "range_start" not in _sent(captured)
-    assert "range_end" not in _sent(captured)
+    assert "range_start" not in captured["body"]
+    assert "range_end" not in captured["body"]
 
     # half-bounded (only since) is allowed too
     captured.clear()
@@ -829,8 +904,8 @@ def test_client_get_events_optional_time_range(app: FastAPI) -> None:
             warehouse_base_url="http://test",
         )
         er_client.get_events(since="2015-01-01T00:00:00", event_type=["a", "b"])
-    assert "range_start" in _sent(captured)
-    assert "range_end" not in _sent(captured)
+    assert "range_start" in captured["body"]
+    assert "range_end" not in captured["body"]
 
 
 def test_client_get_events_forwards_invalid_details(app: FastAPI) -> None:
@@ -851,7 +926,7 @@ def test_client_get_events_forwards_invalid_details(app: FastAPI) -> None:
             include_details=True,
             invalid_details="coerce",
         )
-    assert _sent(captured)["invalid_details"] == "coerce"
+    assert captured["body"]["invalid_details"] == "coerce"
 
 
 def test_client_get_events_rejects_unsupported() -> None:
@@ -942,8 +1017,8 @@ def test_client_get_events_include_and_raw_details_compose(app: FastAPI) -> None
             include_details=True,
             raw_details=True,
         )
-    assert _sent(captured)["raw_details"] is True
-    assert _sent(captured)["include_details"] is True
+    assert captured["body"]["raw_details"] is True
+    assert captured["body"]["include_details"] is True
 
 
 def test_client_get_events_invalid_details_triggers_typed_mode(app: FastAPI) -> None:
@@ -964,9 +1039,9 @@ def test_client_get_events_invalid_details_triggers_typed_mode(app: FastAPI) -> 
             event_type=["wildlife_sighting"],
             invalid_details="drop",
         )
-    assert _sent(captured)["invalid_details"] == "drop"
-    assert _sent(captured)["raw_details"] is False
-    assert _sent(captured)["include_details"] is True
+    assert captured["body"]["invalid_details"] == "drop"
+    assert captured["body"]["raw_details"] is False
+    assert captured["body"]["include_details"] is True
 
 
 def test_client_get_event_types(app: FastAPI) -> None:
@@ -1260,11 +1335,11 @@ def test_client_get_subjectgroup_observations_forwards_exclusion_flags(
             filter=value,
         )
 
-    params = _sent(captured)
+    body = captured["body"]
     if value is None:
-        assert "exclusion_flags" not in params
+        assert "exclusion_flags" not in body
     else:
-        assert params["exclusion_flags"] == value
+        assert body["exclusion_flags"] == value
 
 
 @pytest.mark.parametrize("value", [None, 0, 1, 2, 3])
@@ -1312,11 +1387,11 @@ def test_client_get_patrol_observations_with_patrol_filter_forwards_exclusion_fl
             filter=value,
         )
 
-    params = _sent(captured)
+    body = captured["body"]
     if value is None:
-        assert "exclusion_flags" not in params
+        assert "exclusion_flags" not in body
     else:
-        assert params["exclusion_flags"] == value
+        assert body["exclusion_flags"] == value
 
 
 # -------------------------------------------------------------------------
@@ -1369,8 +1444,8 @@ def test_client_get_patrol_observations_with_patrol_filter_forwards_patrols_over
             include_patrol_details=True,
         )
 
-    params = _sent(captured)
-    assert params["patrols_overlap_daterange"] == value
+    body = captured["body"]
+    assert body["patrols_overlap_daterange"] == value
 
 
 def test_client_get_patrol_observations_with_patrol_filter_default_patrols_overlap_daterange_is_true(
@@ -1415,8 +1490,8 @@ def test_client_get_patrol_observations_with_patrol_filter_default_patrols_overl
             include_patrol_details=True,
         )
 
-    params = _sent(captured)
-    assert params["patrols_overlap_daterange"] is True
+    body = captured["body"]
+    assert body["patrols_overlap_daterange"] is True
 
 
 @pytest.mark.parametrize("value", [True, False])
@@ -1463,8 +1538,8 @@ def test_client_get_patrols_minimal_forwards_patrols_overlap_daterange(
             patrols_overlap_daterange=value,
         )
 
-    params = _sent(captured)
-    assert params["patrols_overlap_daterange"] == value
+    body = captured["body"]
+    assert body["patrols_overlap_daterange"] == value
 
 
 def test_client_get_patrols_minimal_default_patrols_overlap_daterange_is_true(
@@ -1508,8 +1583,8 @@ def test_client_get_patrols_minimal_default_patrols_overlap_daterange_is_true(
             status=["done"],
         )
 
-    params = _sent(captured)
-    assert params["patrols_overlap_daterange"] is True
+    body = captured["body"]
+    assert body["patrols_overlap_daterange"] is True
 
 
 # -------------------------------------------------------------------------
@@ -1633,3 +1708,19 @@ def test_patrol_ids_list_too_long_for_a_url_is_sent_and_applied(
             "http://test/observations/stream/arrow",
             params={"patrol_ids": patrol_ids},
         )
+
+
+def test_empty_patrols_df_sends_no_patrol_ids(app: FastAPI) -> None:
+    """An empty patrols_df must omit patrol_ids, not send an empty list.
+
+    A query string dropped empty-list params outright; a JSON body carries
+    ``[]`` through. A server that did not normalize ``[]`` back to ``None``
+    would read it as "no patrol filter" and scan the whole tenant.
+    """
+    captured: dict = {}
+    with _capture_request(app, captured):
+        _client().get_patrol_observations(
+            patrols_df=pa.table({"id": pa.array([], type=pa.string())}),
+        )
+
+    assert "patrol_ids" not in captured["body"]


### PR DESCRIPTION
Observations, patrols and events now read from the warehouse `/search` routes, so `patrol_ids`/`subject_ids` lists are no longer capped by URL length (httpx rejected the query string past ~1365 UUIDs). `event_types` and `events/schema` stay on GET; both have bounded params.

Related PR: https://github.com/PADAS/earthranger-warehouse-api/pull/88