### PR TITLE
ERA-13955: patrol schema, capture-field query models and Arrow schemas for DWH

### DIFF
--- a/src/ecoscope_earthranger_io_core/arrow.py
+++ b/src/ecoscope_earthranger_io_core/arrow.py
@@ -9,6 +9,13 @@ import geoarrow.pyarrow  # type: ignore[import-untyped]
 import pyarrow as pa
 
 
+# Schema versioning rule: additive, non-breaking changes to a published ``_V1``
+# schema are PERMITTED -- appending a field, or appending a field to a struct it
+# embeds. Removals, renames and type changes are NOT; those require a new ``_V2``
+# constant. An added field only reaches a reader once the column exists in
+# Iceberg, so ship the pipeline migration before the API release that picks it up.
+
+
 OBSERVATIONS_SCHEMA__EARTHRANGER_FULL_V1 = pa.schema(
     [
         ("created_at", pa.string()),
@@ -83,7 +90,60 @@ OBSERVATIONS_WITH_PATROL_SCHEMA_SLIM_V1 = pa.schema(
 # Patrol Schemas
 # =========================================================================
 
-# Struct type for patrol segments (used in nested schema)
+# A patrol leg's team, resolved. das serves the leg's ``team`` as a bare uuid and
+# says so deliberately -- a das client renders the name from
+# ``GET /activity/patrols/config/default/resolved/``. A warehouse consumer cannot
+# call das, so the warehouse resolves it here instead, using that endpoint's own
+# team shape verbatim.
+#
+# ``team_id`` is declared ``db_constraint=False`` with ``on_delete=SET_NULL`` in
+# das, so it may be null and may point at a team that no longer exists. The
+# resolution is a LEFT join: an unresolvable team yields a null struct, never a
+# dropped leg.
+PATROL_TEAM_STRUCT_V1 = pa.struct(
+    [
+        ("id", pa.string()),
+        # ``value`` is the stable key, ``display`` the renameable label. Both are
+        # kept so a team stays trackable across a rename.
+        ("value", pa.string()),
+        ("display", pa.string()),
+        ("ordernum", pa.int64()),
+        ("is_active", pa.bool_()),
+    ]
+)
+
+# A subject on a leg's members or assets roster, resolved. Same reasoning as
+# PATROL_TEAM_STRUCT_V1: das serves bare subject ids, the warehouse resolves
+# them, and the field names are the ones das's resolved roster uses. Two of its
+# fields are deliberately absent -- ``content_type``, which is always
+# ``observations.subject``, and ``image_url``, which is a das static path the
+# warehouse does not ingest.
+#
+# Order carries meaning (das duplicates the leader into the members list), and an
+# Arrow list is ordered by construction, so the link tables' ``ordernum`` decides
+# the order of this list rather than appearing as a field of it -- exactly as das
+# serves plain ordered arrays.
+PATROL_SEGMENT_SUBJECT_STRUCT_V1 = pa.struct(
+    [
+        ("id", pa.string()),
+        ("name", pa.string()),
+        # Resolved through subjects -> subject_subtypes -> subject_types. das
+        # splits members from assets by this: members are ``person``, assets are
+        # anything not ``person``, ``wildlife`` or ``stationary-object``.
+        ("subject_type", pa.string()),
+        ("subject_subtype", pa.string()),
+        ("subject_subtype_display", pa.string()),
+        ("is_active", pa.bool_()),
+    ]
+)
+
+# Struct type for patrol segments (used in nested schema).
+#
+# The trailing six are the capture fields a leg records under the patrol_schemas
+# preview feature. They are appended, not interleaved, so the cast stays
+# positionally stable for existing readers (see the versioning rule at the top of
+# this module). A tenant without the feature -- and any row ingested before the
+# columns existed -- carries nulls; that is a normal state, not an error.
 PATROL_SEGMENT_STRUCT_V1 = pa.struct(
     [
         ("id", pa.string()),
@@ -96,6 +156,33 @@ PATROL_SEGMENT_STRUCT_V1 = pa.struct(
         ("scheduled_end", pa.string()),
         ("start_location", pa.string()),
         ("end_location", pa.string()),
+        # Captured against the tenant's site-wide segment schema. JSON text here;
+        # the API swaps in a struct derived from that schema when typed details
+        # are requested, exactly as ``event_details`` works. The site-wide schema
+        # is one per tenant, so this column is homogeneous and can always be
+        # typed -- no single-patrol-type restriction applies to it.
+        #     NULL   not captured, or the tenant has no patrol_schemas
+        #     '{}'   captured, and empty (das never reads details back as null)
+        #     JSON   the captured fields
+        ("segment_details", pa.string()),
+        # Captured against the leg's OWN patrol type schema, so a query spanning
+        # several patrol types is heterogeneous and one struct cannot describe it.
+        # Typing this one requires the query to name exactly one patrol type;
+        # otherwise it stays JSON text. Same null/'{}' convention as above.
+        ("type_details", pa.string()),
+        # See PATROL_TEAM_STRUCT_V1 / PATROL_SEGMENT_SUBJECT_STRUCT_V1. Empty
+        # rosters are ``[]``, matching das; NULL means not captured.
+        ("team", PATROL_TEAM_STRUCT_V1),
+        ("members", pa.list_(PATROL_SEGMENT_SUBJECT_STRUCT_V1)),
+        ("assets", pa.list_(PATROL_SEGMENT_SUBJECT_STRUCT_V1)),
+        # True marks the leg as a pause rather than active patrolling. das
+        # excludes paused legs by default (PatrolsQuery.include_pauses mirrors
+        # that). NULL on warehouse rows written before the column existed: the
+        # das column is NOT NULL DEFAULT false, but warehouse history only gets a
+        # value from a backfill. TREAT NULL AS NOT-A-PAUSE -- filtering
+        # ``is_pause = false`` silently drops every un-backfilled leg, so the
+        # predicate is ``is_pause IS NOT TRUE``.
+        ("is_pause", pa.bool_()),
     ]
 )
 
@@ -135,6 +222,15 @@ PATROLS_FLAT_SCHEMA_V1 = pa.schema(
         ("scheduled_end", pa.string()),
         ("start_location", pa.string()),
         ("end_location", pa.string()),
+        # Capture fields -- see PATROL_SEGMENT_STRUCT_V1 for the full semantics of
+        # each (null/'{}' conventions, the typed-details rules, and why NULL
+        # is_pause means not-a-pause).
+        ("segment_details", pa.string()),
+        ("type_details", pa.string()),
+        ("team", PATROL_TEAM_STRUCT_V1),
+        ("members", pa.list_(PATROL_SEGMENT_SUBJECT_STRUCT_V1)),
+        ("assets", pa.list_(PATROL_SEGMENT_SUBJECT_STRUCT_V1)),
+        ("is_pause", pa.bool_()),
     ]
 )
 
@@ -241,8 +337,12 @@ PATROL_SEGMENT_WITH_EVENTS_STRUCT_V1 = pa.struct(
 )
 
 # Nested patrols schema WITH events — selected only when include_events=true.
-# This is a NEW versioned schema: PATROLS_NESTED_SCHEMA_V1 is left untouched
-# (never mutate a published versioned schema). It has the same top-level columns
+# This is a SEPARATE versioned schema rather than a flag on PATROLS_NESTED_SCHEMA_V1
+# because its segments carry a different struct, not because published schemas are
+# frozen: appending to one is permitted, and PATROL_SEGMENT_STRUCT_V1's capture
+# fields were appended in place for exactly that reason. See the versioning rule at
+# the top of this module for what is and is not allowed, and for the deploy-ordering
+# constraint that makes an addition safe. It has the same top-level columns
 # as PATROLS_NESTED_SCHEMA_V1, but each patrol segment carries its own events
 # (events are nested under ``patrol_segments[].events[]``, not at the top level).
 PATROLS_WITH_EVENTS_NESTED_SCHEMA_V1 = pa.schema(
@@ -283,6 +383,15 @@ PATROL_EVENTS_FLAT_SCHEMA_V1 = pa.schema(
         ("patrol_segment_id", pa.string()),
         ("patrol_type", pa.string()),
         ("patrol_start_time", pa.string()),
+        # Capture fields -- see PATROL_SEGMENT_STRUCT_V1 for the full semantics of
+        # each (null/'{}' conventions, the typed-details rules, and why NULL
+        # is_pause means not-a-pause).
+        ("segment_details", pa.string()),
+        ("type_details", pa.string()),
+        ("team", PATROL_TEAM_STRUCT_V1),
+        ("members", pa.list_(PATROL_SEGMENT_SUBJECT_STRUCT_V1)),
+        ("assets", pa.list_(PATROL_SEGMENT_SUBJECT_STRUCT_V1)),
+        ("is_pause", pa.bool_()),
     ]
 )
 
@@ -297,6 +406,27 @@ EVENT_TYPES_SCHEMA_V1 = pa.schema(
         ("category_display", pa.string()),
         ("is_active", pa.bool_()),
         ("is_collection", pa.bool_()),
+    ]
+)
+
+
+# Listing schema for the warehouse ``GET /patrol_types`` endpoint — the patrol
+# counterpart of EVENT_TYPES_SCHEMA_V1, and the contract for patrol-type
+# display-name resolution.
+#
+# It deliberately does NOT carry the patrol type's schema document, for the same
+# reason EVENT_TYPES_SCHEMA_V1 does not: the document is served by the schema
+# endpoints, as serialized Arrow IPC schema bytes or as a JSON mapping, never as a
+# table column. Widening every row of a listing by a per-type JSON blob to save a
+# second request is a bad trade, and it would force a listing reader to parse a
+# schema it did not ask for.
+PATROL_TYPES_SCHEMA_V1 = pa.schema(
+    [  # type: ignore[arg-type]
+        ("id", pa.string()),
+        ("value", pa.string()),
+        ("display", pa.string()),
+        ("ordernum", pa.int64()),
+        ("is_active", pa.bool_()),
     ]
 )
 

--- a/src/ecoscope_earthranger_io_core/arrow.py
+++ b/src/ecoscope_earthranger_io_core/arrow.py
@@ -90,21 +90,11 @@ OBSERVATIONS_WITH_PATROL_SCHEMA_SLIM_V1 = pa.schema(
 # Patrol Schemas
 # =========================================================================
 
-# A patrol leg's team, resolved. das serves the leg's ``team`` as a bare uuid and
-# says so deliberately -- a das client renders the name from
-# ``GET /activity/patrols/config/default/resolved/``. A warehouse consumer cannot
-# call das, so the warehouse resolves it here instead, using that endpoint's own
-# team shape verbatim.
-#
-# ``team_id`` is declared ``db_constraint=False`` with ``on_delete=SET_NULL`` in
-# das, so it may be null and may point at a team that no longer exists. The
-# resolution is a LEFT join: an unresolvable team yields a null struct, never a
-# dropped leg.
+# A leg's team, resolved to names rather than a bare id. The reference may be null
+# or dangling, so an unresolvable team must yield a null struct, never a dropped leg.
 PATROL_TEAM_STRUCT_V1 = pa.struct(
     [
         ("id", pa.string()),
-        # ``value`` is the stable key, ``display`` the renameable label. Both are
-        # kept so a team stays trackable across a rename.
         ("value", pa.string()),
         ("display", pa.string()),
         ("ordernum", pa.int64()),
@@ -112,24 +102,15 @@ PATROL_TEAM_STRUCT_V1 = pa.struct(
     ]
 )
 
-# A subject on a leg's members or assets roster, resolved. Same reasoning as
-# PATROL_TEAM_STRUCT_V1: das serves bare subject ids, the warehouse resolves
-# them, and the field names are the ones das's resolved roster uses. Two of its
-# fields are deliberately absent -- ``content_type``, which is always
-# ``observations.subject``, and ``image_url``, which is a das static path the
-# warehouse does not ingest.
-#
-# Order carries meaning (das duplicates the leader into the members list), and an
-# Arrow list is ordered by construction, so the link tables' ``ordernum`` decides
-# the order of this list rather than appearing as a field of it -- exactly as das
-# serves plain ordered arrays.
+# A subject on a leg's members or assets roster, resolved for the same reason as
+# PATROL_TEAM_STRUCT_V1. Roster order carries meaning but is not a field here:
+# an Arrow list is ordered, so the API's ordering reaches the consumer intact.
 PATROL_SEGMENT_SUBJECT_STRUCT_V1 = pa.struct(
     [
         ("id", pa.string()),
         ("name", pa.string()),
-        # Resolved through subjects -> subject_subtypes -> subject_types. das
-        # splits members from assets by this: members are ``person``, assets are
-        # anything not ``person``, ``wildlife`` or ``stationary-object``.
+        # Carried because members and assets are split by subject type, so a
+        # consumer cannot interpret either roster without it.
         ("subject_type", pa.string()),
         ("subject_subtype", pa.string()),
         ("subject_subtype_display", pa.string()),
@@ -139,11 +120,9 @@ PATROL_SEGMENT_SUBJECT_STRUCT_V1 = pa.struct(
 
 # Struct type for patrol segments (used in nested schema).
 #
-# The trailing six are the capture fields a leg records under the patrol_schemas
-# preview feature. They are appended, not interleaved, so the cast stays
-# positionally stable for existing readers (see the versioning rule at the top of
-# this module). A tenant without the feature -- and any row ingested before the
-# columns existed -- carries nulls; that is a normal state, not an error.
+# The trailing six are a leg's capture fields, appended rather than interleaved so
+# existing readers are undisturbed. They are null for a tenant without the feature
+# and for rows predating the columns; that is a normal state, not an error.
 PATROL_SEGMENT_STRUCT_V1 = pa.struct(
     [
         ("id", pa.string()),
@@ -156,32 +135,20 @@ PATROL_SEGMENT_STRUCT_V1 = pa.struct(
         ("scheduled_end", pa.string()),
         ("start_location", pa.string()),
         ("end_location", pa.string()),
-        # Captured against the tenant's site-wide segment schema. JSON text here;
-        # the API swaps in a struct derived from that schema when typed details
-        # are requested, exactly as ``event_details`` works. The site-wide schema
-        # is one per tenant, so this column is homogeneous and can always be
-        # typed -- no single-patrol-type restriction applies to it.
-        #     NULL   not captured, or the tenant has no patrol_schemas
-        #     '{}'   captured, and empty (das never reads details back as null)
-        #     JSON   the captured fields
+        # JSON text; the API swaps in a typed struct on request, as with
+        # ``event_details``. NULL means not captured, '{}' means captured-empty.
+        # One schema per tenant shapes this, so it can always be typed.
         ("segment_details", pa.string()),
-        # Captured against the leg's OWN patrol type schema, so a query spanning
-        # several patrol types is heterogeneous and one struct cannot describe it.
-        # Typing this one requires the query to name exactly one patrol type;
-        # otherwise it stays JSON text. Same null/'{}' convention as above.
+        # As above, but shaped by each leg's own patrol type -- so a query
+        # spanning several types cannot be typed and stays JSON text.
         ("type_details", pa.string()),
-        # See PATROL_TEAM_STRUCT_V1 / PATROL_SEGMENT_SUBJECT_STRUCT_V1. Empty
-        # rosters are ``[]``, matching das; NULL means not captured.
+        # An empty roster is ``[]``; NULL means not captured.
         ("team", PATROL_TEAM_STRUCT_V1),
         ("members", pa.list_(PATROL_SEGMENT_SUBJECT_STRUCT_V1)),
         ("assets", pa.list_(PATROL_SEGMENT_SUBJECT_STRUCT_V1)),
-        # True marks the leg as a pause rather than active patrolling. das
-        # excludes paused legs by default (PatrolsQuery.include_pauses mirrors
-        # that). NULL on warehouse rows written before the column existed: the
-        # das column is NOT NULL DEFAULT false, but warehouse history only gets a
-        # value from a backfill. TREAT NULL AS NOT-A-PAUSE -- filtering
-        # ``is_pause = false`` silently drops every un-backfilled leg, so the
-        # predicate is ``is_pause IS NOT TRUE``.
+        # Marks the leg as a pause rather than active patrolling; excluded by
+        # default (see PatrolsQuery.include_pauses). TREAT NULL AS NOT-A-PAUSE:
+        # it is null until backfilled, so ``= false`` drops every historical leg.
         ("is_pause", pa.bool_()),
     ]
 )
@@ -222,9 +189,7 @@ PATROLS_FLAT_SCHEMA_V1 = pa.schema(
         ("scheduled_end", pa.string()),
         ("start_location", pa.string()),
         ("end_location", pa.string()),
-        # Capture fields -- see PATROL_SEGMENT_STRUCT_V1 for the full semantics of
-        # each (null/'{}' conventions, the typed-details rules, and why NULL
-        # is_pause means not-a-pause).
+        # Capture fields; see PATROL_SEGMENT_STRUCT_V1 for their semantics.
         ("segment_details", pa.string()),
         ("type_details", pa.string()),
         ("team", PATROL_TEAM_STRUCT_V1),
@@ -337,12 +302,9 @@ PATROL_SEGMENT_WITH_EVENTS_STRUCT_V1 = pa.struct(
 )
 
 # Nested patrols schema WITH events — selected only when include_events=true.
-# This is a SEPARATE versioned schema rather than a flag on PATROLS_NESTED_SCHEMA_V1
-# because its segments carry a different struct, not because published schemas are
-# frozen: appending to one is permitted, and PATROL_SEGMENT_STRUCT_V1's capture
-# fields were appended in place for exactly that reason. See the versioning rule at
-# the top of this module for what is and is not allowed, and for the deploy-ordering
-# constraint that makes an addition safe. It has the same top-level columns
+# This is a SEPARATE schema because its segments carry a different struct, not
+# because published schemas are frozen -- appending to one is permitted (see the
+# versioning rule at the top of this module). It has the same top-level columns
 # as PATROLS_NESTED_SCHEMA_V1, but each patrol segment carries its own events
 # (events are nested under ``patrol_segments[].events[]``, not at the top level).
 PATROLS_WITH_EVENTS_NESTED_SCHEMA_V1 = pa.schema(
@@ -383,9 +345,7 @@ PATROL_EVENTS_FLAT_SCHEMA_V1 = pa.schema(
         ("patrol_segment_id", pa.string()),
         ("patrol_type", pa.string()),
         ("patrol_start_time", pa.string()),
-        # Capture fields -- see PATROL_SEGMENT_STRUCT_V1 for the full semantics of
-        # each (null/'{}' conventions, the typed-details rules, and why NULL
-        # is_pause means not-a-pause).
+        # Capture fields; see PATROL_SEGMENT_STRUCT_V1 for their semantics.
         ("segment_details", pa.string()),
         ("type_details", pa.string()),
         ("team", PATROL_TEAM_STRUCT_V1),
@@ -410,16 +370,10 @@ EVENT_TYPES_SCHEMA_V1 = pa.schema(
 )
 
 
-# Listing schema for the warehouse ``GET /patrol_types`` endpoint — the patrol
-# counterpart of EVENT_TYPES_SCHEMA_V1, and the contract for patrol-type
-# display-name resolution.
-#
-# It deliberately does NOT carry the patrol type's schema document, for the same
-# reason EVENT_TYPES_SCHEMA_V1 does not: the document is served by the schema
-# endpoints, as serialized Arrow IPC schema bytes or as a JSON mapping, never as a
-# table column. Widening every row of a listing by a per-type JSON blob to save a
-# second request is a bad trade, and it would force a listing reader to parse a
-# schema it did not ask for.
+# Listing schema for ``GET /patrol_types`` — the patrol counterpart of
+# EVENT_TYPES_SCHEMA_V1, for display-name resolution. It carries no schema
+# document: that is per-type and served separately, and widening every listing
+# row with it would burden readers that never asked for it.
 PATROL_TYPES_SCHEMA_V1 = pa.schema(
     [  # type: ignore[arg-type]
         ("id", pa.string()),

--- a/src/ecoscope_earthranger_io_core/client.py
+++ b/src/ecoscope_earthranger_io_core/client.py
@@ -708,6 +708,17 @@ class ERWarehouseClient(BaseModel):
                             "patrol_segment_id": segment.get("id"),
                             "patrol_type": segment.get("patrol_type"),
                             "patrol_start_time": segment.get("time_range_start"),
+                            # The segment's capture fields, carried as event
+                            # context. ``.get`` rather than indexing: a server
+                            # that predates these columns simply yields nulls,
+                            # which is also what a tenant without the
+                            # patrol_schemas preview feature yields.
+                            "segment_details": segment.get("segment_details"),
+                            "type_details": segment.get("type_details"),
+                            "team": segment.get("team"),
+                            "members": segment.get("members"),
+                            "assets": segment.get("assets"),
+                            "is_pause": segment.get("is_pause"),
                         }
                     )
         return pa.Table.from_pylist(rows, schema=PATROL_EVENTS_FLAT_SCHEMA_V1)

--- a/src/ecoscope_earthranger_io_core/query.py
+++ b/src/ecoscope_earthranger_io_core/query.py
@@ -39,6 +39,30 @@ _INCLUDE_SUBJECT_ADDITIONAL_DESCRIPTION = (
 )
 
 
+_INCLUDE_PAUSES_DESCRIPTION = (
+    "If True, include patrol legs flagged as a pause rather than active "
+    "patrolling; if False (default), exclude them -- matching EarthRanger, so "
+    "totals such as distance and duration agree with what the product reports. "
+    "A leg ingested before the pause flag existed has no value for it and is "
+    "treated as not-a-pause, so excluding pauses never silently drops history."
+)
+
+_PATROL_RAW_DETAILS_DESCRIPTION = (
+    "Format override: serve `segment_details` and `type_details` as flat JSON "
+    "strings instead of typed structs. Set this to query across several patrol "
+    "types at once -- `type_details` is shaped by each leg's own patrol type, so "
+    "typing it requires the query to name exactly one. (`segment_details` is "
+    "shaped by the tenant's single site-wide segment schema and carries no such "
+    "restriction.)"
+)
+
+_PATROL_PARSE_DETAIL_DATETIMES_DESCRIPTION = (
+    "Typed-struct only: map `segment_details` / `type_details` date-time and "
+    "date fields to Arrow timestamp/date instead of strings. Ignored when "
+    "raw_details is True."
+)
+
+
 class ObservationsQuery(_WarehouseQuery):
     """An EarthRanger observations query.
 
@@ -293,6 +317,18 @@ class PatrolsQuery(_WarehouseQuery):
     include_patrol_segments: bool = False
     include_events: bool = True
     flat: bool = True
+    include_pauses: bool = Field(
+        default=False,
+        description=_INCLUDE_PAUSES_DESCRIPTION,
+    )
+    raw_details: bool = Field(
+        default=False,
+        description=_PATROL_RAW_DETAILS_DESCRIPTION,
+    )
+    parse_detail_datetimes: bool = Field(
+        default=False,
+        description=_PATROL_PARSE_DETAIL_DATETIMES_DESCRIPTION,
+    )
 
     @classmethod
     def from_query_params(
@@ -307,6 +343,18 @@ class PatrolsQuery(_WarehouseQuery):
         include_patrol_segments: bool = Query(False),
         include_events: bool = Query(True),
         flat: bool = Query(True),
+        include_pauses: bool = Query(
+            False,
+            description=_INCLUDE_PAUSES_DESCRIPTION,
+        ),
+        raw_details: bool = Query(
+            False,
+            description=_PATROL_RAW_DETAILS_DESCRIPTION,
+        ),
+        parse_detail_datetimes: bool = Query(
+            False,
+            description=_PATROL_PARSE_DETAIL_DATETIMES_DESCRIPTION,
+        ),
     ) -> "PatrolsQuery":
         return cls(
             tenant_domain=tenant_domain,
@@ -319,7 +367,129 @@ class PatrolsQuery(_WarehouseQuery):
             include_patrol_segments=include_patrol_segments,
             include_events=include_events,
             flat=flat,
+            include_pauses=include_pauses,
+            raw_details=raw_details,
+            parse_detail_datetimes=parse_detail_datetimes,
         )
+
+
+class PatrolTypesQuery(_TenantQuery):
+    """Query for the warehouse /patrol_types listing (tenant-scoped).
+
+    The patrol counterpart of ``EventTypesQuery``. The listing itself streams
+    against ``PATROL_TYPES_SCHEMA_V1``, which carries display names but not the
+    per-type schema documents; ``include_schema`` asks for those documents
+    alongside it, so a consumer building a form for every patrol type does not
+    have to follow up with one ``PatrolTypeSchemaQuery`` per type.
+
+    What "schema document" means: das stores each patrol type's schema as a
+    ``{"json": <JSON-Schema>, "ui": <form layout>}`` envelope. The API derives
+    the typed ``type_details`` Arrow struct from the ``json`` half -- so a
+    schema endpoint can serve either the derived Arrow struct or the stored
+    document, and neither belongs in a listing row.
+
+    Examples:
+
+    ```python
+    >>> from ecoscope_earthranger_io_core.query import PatrolTypesQuery
+    >>> query = PatrolTypesQuery(tenant_domain="some-site.pamdas.org")
+    >>> query.include_schema
+    False
+
+    ```
+
+    Or asking for the schema documents too:
+
+    ```python
+    >>> query = PatrolTypesQuery(
+    ...     tenant_domain="some-site.pamdas.org",
+    ...     include_schema=True,
+    ... )
+    >>>
+    ```
+    """
+
+    include_schema: bool = Field(
+        default=False,
+        description=(
+            "If True, return each patrol type's schema document alongside the "
+            "listing; if False (default), return the listing alone. A schema "
+            "document is never a column of the Arrow listing -- it is a "
+            "per-type document served in its own right, the same way "
+            "`/events/schema` serves an event type's."
+        ),
+    )
+
+    @classmethod
+    def from_query_params(
+        cls,
+        tenant_domain: str = Query(...),
+        include_schema: bool = Query(False),
+    ) -> "PatrolTypesQuery":
+        return cls(tenant_domain=tenant_domain, include_schema=include_schema)
+
+
+class PatrolTypeSchemaQuery(_TenantQuery):
+    """Lookup for a single patrol type's ``type_details`` schema.
+
+    The patrol counterpart of ``EventTypeSchemaQuery``, and single-keyed for the
+    same reason: the typed ``type_details`` struct is derived from exactly one
+    patrol type's schema document.
+
+    ``patrol_type_value`` accepts either the patrol type's UUID or its ``value``
+    slug, as das does -- one key, two accepted spellings of it, rather than two
+    fields where a caller could set both.
+
+    Examples:
+
+    ```python
+    >>> from ecoscope_earthranger_io_core.query import PatrolTypeSchemaQuery
+    >>> query = PatrolTypeSchemaQuery(
+    ...     tenant_domain="some-site.pamdas.org",
+    ...     patrol_type_value="routine_patrol",
+    ... )
+    >>>
+    ```
+    """
+
+    patrol_type_value: str
+
+    @classmethod
+    def from_query_params(
+        cls,
+        tenant_domain: str = Query(...),
+        patrol_type_value: str = Query(...),
+    ) -> "PatrolTypeSchemaQuery":
+        return cls(tenant_domain=tenant_domain, patrol_type_value=patrol_type_value)
+
+
+class SegmentSchemaQuery(_TenantQuery):
+    """Lookup for the tenant's site-wide patrol segment ("leg") schema.
+
+    Tenant is the only key: unlike patrol types, there is exactly one segment
+    schema per tenant, and it shapes the ``segment_details`` of every leg. That
+    is also why ``segment_details`` can always be served as a typed struct, with
+    no restriction on how many patrol types a patrol query spans.
+
+    A tenant that never authored a schema is a normal state, not an absent one:
+    das stores its canonical empty ``{json, ui}`` envelope, so this lookup has no
+    "not found" case to model.
+
+    Examples:
+
+    ```python
+    >>> from ecoscope_earthranger_io_core.query import SegmentSchemaQuery
+    >>> query = SegmentSchemaQuery(tenant_domain="some-site.pamdas.org")
+    >>>
+    ```
+    """
+
+    @classmethod
+    def from_query_params(
+        cls,
+        tenant_domain: str = Query(...),
+    ) -> "SegmentSchemaQuery":
+        return cls(tenant_domain=tenant_domain)
 
 
 class _PatrolsQuery(_WarehouseQuery):

--- a/tests/test_events_arrow.py
+++ b/tests/test_events_arrow.py
@@ -7,7 +7,9 @@ from ecoscope_earthranger_io_core.arrow import (
     PATROL_EVENT_STRUCT_V1,
     PATROL_EVENTS_FLAT_SCHEMA_V1,
     PATROL_SEGMENT_STRUCT_V1,
+    PATROL_SEGMENT_SUBJECT_STRUCT_V1,
     PATROL_SEGMENT_WITH_EVENTS_STRUCT_V1,
+    PATROL_TEAM_STRUCT_V1,
     PATROLS_NESTED_SCHEMA_V1,
     PATROLS_WITH_EVENTS_NESTED_SCHEMA_V1,
     REPORTED_BY_STRUCT_V1,
@@ -37,6 +39,14 @@ def test_patrol_events_flat_schema_v1_fields():
         ("patrol_segment_id", pa.string()),
         ("patrol_type", pa.string()),
         ("patrol_start_time", pa.string()),
+        # ERA-13955: the segment's capture fields, carried as event context.
+        # Types are asserted in test_patrols_arrow.py; this test owns the order.
+        ("segment_details", pa.string()),
+        ("type_details", pa.string()),
+        ("team", PATROL_TEAM_STRUCT_V1),
+        ("members", pa.list_(PATROL_SEGMENT_SUBJECT_STRUCT_V1)),
+        ("assets", pa.list_(PATROL_SEGMENT_SUBJECT_STRUCT_V1)),
+        ("is_pause", pa.bool_()),
     ]
     assert PATROL_EVENTS_FLAT_SCHEMA_V1.names == [n for n, _ in expected]
     for name, typ in expected:
@@ -157,8 +167,10 @@ def test_patrol_segment_with_events_struct_v1_fields():
 
 def test_patrols_nested_schema_v1_unchanged():
     """Regression guard: the published PATROLS_NESTED_SCHEMA_V1 must NOT gain an
-    events column, and PATROL_SEGMENT_STRUCT_V1 must NOT gain an events field
-    (never mutate a published versioned schema)."""
+    events column, and PATROL_SEGMENT_STRUCT_V1 must NOT gain an events field --
+    events belong to the with-events schema alone. This is a shape rule, not a
+    freeze: appending non-events fields to these is permitted (the capture fields
+    were), per the versioning rule at the top of arrow.py."""
     assert PATROLS_NESTED_SCHEMA_V1.names == [
         "id",
         "serial_number",

--- a/tests/test_events_query.py
+++ b/tests/test_events_query.py
@@ -127,5 +127,8 @@ def test_patrols_query_from_query_params_include_events(include_events):
         include_patrol_segments=False,
         include_events=include_events,
         flat=True,
+        include_pauses=False,
+        raw_details=False,
+        parse_detail_datetimes=False,
     )
     assert q.include_events is include_events

--- a/tests/test_patrols_arrow.py
+++ b/tests/test_patrols_arrow.py
@@ -1,0 +1,306 @@
+import pyarrow as pa
+
+from ecoscope_earthranger_io_core.arrow import (
+    PATROL_EVENTS_FLAT_SCHEMA_V1,
+    PATROL_SEGMENT_STRUCT_V1,
+    PATROL_SEGMENT_SUBJECT_STRUCT_V1,
+    PATROL_SEGMENT_WITH_EVENTS_STRUCT_V1,
+    PATROL_TEAM_STRUCT_V1,
+    PATROL_TYPES_SCHEMA_V1,
+    PATROLS_FLAT_SCHEMA_V1,
+    PATROLS_NESTED_SCHEMA_V1,
+    PATROLS_ONLY_SCHEMA_V1,
+    PATROLS_WITH_EVENTS_NESTED_SCHEMA_V1,
+)
+
+
+# The six capture fields, in the order they are appended, with their types.
+CAPTURE_FIELDS = [
+    ("segment_details", pa.string()),
+    ("type_details", pa.string()),
+    ("team", PATROL_TEAM_STRUCT_V1),
+    ("members", pa.list_(PATROL_SEGMENT_SUBJECT_STRUCT_V1)),
+    ("assets", pa.list_(PATROL_SEGMENT_SUBJECT_STRUCT_V1)),
+    ("is_pause", pa.bool_()),
+]
+
+# PATROL_SEGMENT_STRUCT_V1's fields as published before the capture fields were
+# appended. Spelled out rather than sliced, so a rename or a type change to any
+# of them fails here instead of silently shifting.
+PRE_CAPTURE_SEGMENT_FIELDS = [
+    ("id", pa.string()),
+    ("patrol_type", pa.string()),
+    ("patrol_type_display", pa.string()),
+    ("leader_id", pa.string()),
+    ("time_range_start", pa.string()),
+    ("time_range_end", pa.string()),
+    ("scheduled_start", pa.string()),
+    ("scheduled_end", pa.string()),
+    ("start_location", pa.string()),
+    ("end_location", pa.string()),
+]
+
+
+def _struct_names(struct: pa.StructType) -> list[str]:
+    return [struct.field(i).name for i in range(struct.num_fields)]
+
+
+def test_patrol_team_struct_v1_fields():
+    """The team shape is das's own resolved-config team object, so a warehouse
+    consumer and a das consumer describe a team the same way."""
+    expected = [
+        ("id", pa.string()),
+        ("value", pa.string()),
+        ("display", pa.string()),
+        ("ordernum", pa.int64()),
+        ("is_active", pa.bool_()),
+    ]
+    assert _struct_names(PATROL_TEAM_STRUCT_V1) == [n for n, _ in expected]
+    for name, typ in expected:
+        assert PATROL_TEAM_STRUCT_V1.field(name).type == typ
+
+
+def test_patrol_segment_subject_struct_v1_fields():
+    """Members and assets share one shape, taken from das's resolved roster
+    minus ``content_type`` (a constant) and ``image_url`` (not ingested). No
+    ``ordernum`` field: an Arrow list is ordered, so the link tables' ordernum
+    decides list order rather than appearing in it."""
+    expected = [
+        ("id", pa.string()),
+        ("name", pa.string()),
+        ("subject_type", pa.string()),
+        ("subject_subtype", pa.string()),
+        ("subject_subtype_display", pa.string()),
+        ("is_active", pa.bool_()),
+    ]
+    assert _struct_names(PATROL_SEGMENT_SUBJECT_STRUCT_V1) == [n for n, _ in expected]
+    for name, typ in expected:
+        assert PATROL_SEGMENT_SUBJECT_STRUCT_V1.field(name).type == typ
+    for absent in ("ordernum", "content_type", "image_url"):
+        assert absent not in _struct_names(PATROL_SEGMENT_SUBJECT_STRUCT_V1)
+
+
+def test_patrol_segment_struct_v1_appends_capture_fields():
+    """The capture fields are APPENDED to the published struct -- every
+    pre-existing field keeps its name, type and position."""
+    expected = PRE_CAPTURE_SEGMENT_FIELDS + CAPTURE_FIELDS
+    assert _struct_names(PATROL_SEGMENT_STRUCT_V1) == [n for n, _ in expected]
+    for name, typ in expected:
+        assert PATROL_SEGMENT_STRUCT_V1.field(name).type == typ
+
+
+def test_capture_fields_are_nullable():
+    """A tenant without the patrol_schemas preview feature, and any row ingested
+    before the columns existed, carries nulls. That is a normal state."""
+    for name, _ in CAPTURE_FIELDS:
+        assert PATROL_SEGMENT_STRUCT_V1.field(name).nullable
+        assert PATROLS_FLAT_SCHEMA_V1.field(name).nullable
+
+
+def test_details_columns_are_json_strings():
+    """Both detail columns are JSON text here; the typed struct is derived at
+    query time by the API from the relevant schema document, as event_details is."""
+    assert PATROL_SEGMENT_STRUCT_V1.field("segment_details").type == pa.string()
+    assert PATROL_SEGMENT_STRUCT_V1.field("type_details").type == pa.string()
+
+
+def test_patrols_flat_schema_v1_appends_capture_columns():
+    """The flat schema gains the same six as top-level columns, appended after
+    the existing segment columns."""
+    expected = [
+        ("id", pa.string()),
+        ("serial_number", pa.int64()),
+        ("priority", pa.int64()),
+        ("state", pa.string()),
+        ("title", pa.string()),
+        ("objective", pa.string()),
+        ("created_at", pa.string()),
+        ("updated_at", pa.string()),
+        ("segment_id", pa.string()),
+        ("patrol_type", pa.string()),
+        ("patrol_type_display", pa.string()),
+        ("leader_id", pa.string()),
+        ("time_range_start", pa.string()),
+        ("time_range_end", pa.string()),
+        ("scheduled_start", pa.string()),
+        ("scheduled_end", pa.string()),
+        ("start_location", pa.string()),
+        ("end_location", pa.string()),
+    ] + CAPTURE_FIELDS
+    assert PATROLS_FLAT_SCHEMA_V1.names == [n for n, _ in expected]
+    for name, typ in expected:
+        assert PATROLS_FLAT_SCHEMA_V1.field(name).type == typ
+
+
+def test_embedding_schemas_pick_up_the_capture_fields():
+    """The nested schemas embed PATROL_SEGMENT_STRUCT_V1 by reference, so they
+    inherit the capture fields rather than restating them."""
+    for schema in (PATROLS_NESTED_SCHEMA_V1, PATROLS_WITH_EVENTS_NESTED_SCHEMA_V1):
+        segment_type = schema.field("patrol_segments").type.value_type
+        for name, typ in CAPTURE_FIELDS:
+            assert segment_type.field(name).type == typ
+
+
+def test_patrol_segment_with_events_struct_keeps_leader_name_and_events_last():
+    """The with-events struct is the segment struct + leader_name + events. The
+    capture fields land inside the segment-struct prefix, so leader_name and
+    events stay trailing."""
+    assert _struct_names(PATROL_SEGMENT_WITH_EVENTS_STRUCT_V1) == _struct_names(
+        PATROL_SEGMENT_STRUCT_V1
+    ) + ["leader_name", "events"]
+
+
+def test_patrol_events_flat_schema_v1_appends_capture_columns():
+    """The one-row-per-event flat schema carries its segment's capture fields as
+    context, appended after the existing patrol/segment context columns."""
+    assert PATROL_EVENTS_FLAT_SCHEMA_V1.names[-6:] == [n for n, _ in CAPTURE_FIELDS]
+    for name, typ in CAPTURE_FIELDS:
+        assert PATROL_EVENTS_FLAT_SCHEMA_V1.field(name).type == typ
+    # The pre-existing columns are untouched, in order.
+    assert PATROL_EVENTS_FLAT_SCHEMA_V1.names[:17] == [
+        "id",
+        "serial_number",
+        "event_type",
+        "event_time",
+        "priority",
+        "title",
+        "state",
+        "updated_at",
+        "created_at",
+        "geometry",
+        "is_collection",
+        "event_details",
+        "patrol_id",
+        "patrol_serial_number",
+        "patrol_segment_id",
+        "patrol_type",
+        "patrol_start_time",
+    ]
+
+
+def test_patrol_events_flat_schema_tolerates_rows_missing_capture_keys():
+    """``get_patrol_events`` builds against this constant with
+    ``pa.Table.from_pylist``. Appending columns must not break a row dict that
+    predates them -- from_pylist fills an absent key with null."""
+    table = pa.Table.from_pylist(
+        [{"id": "e1", "patrol_id": "p1"}], schema=PATROL_EVENTS_FLAT_SCHEMA_V1
+    )
+    row = table.to_pylist()[0]
+    assert row["id"] == "e1"
+    for name, _ in CAPTURE_FIELDS:
+        assert row[name] is None
+
+
+def test_patrols_only_schema_v1_is_unaffected():
+    """PATROLS_ONLY_SCHEMA_V1 has no segment columns, so it carries no capture
+    fields either."""
+    assert PATROLS_ONLY_SCHEMA_V1.names == [
+        "id",
+        "serial_number",
+        "priority",
+        "state",
+        "title",
+        "objective",
+        "created_at",
+        "updated_at",
+    ]
+    for name, _ in CAPTURE_FIELDS:
+        assert name not in PATROLS_ONLY_SCHEMA_V1.names
+
+
+def test_no_v2_patrol_schema_exists():
+    """The capture fields were appended to the published _V1 schemas rather than
+    minting _V2 variants; guard against one creeping back in."""
+    import ecoscope_earthranger_io_core.arrow as arrow_module
+
+    assert not [n for n in dir(arrow_module) if n.startswith("PATROL") and "_V2" in n]
+
+
+def test_patrol_types_schema_v1_fields():
+    """Lock the /patrol_types listing contract (patrol-type display-name
+    resolution), mirroring EVENT_TYPES_SCHEMA_V1."""
+    expected = [
+        ("id", pa.string()),
+        ("value", pa.string()),
+        ("display", pa.string()),
+        ("ordernum", pa.int64()),
+        ("is_active", pa.bool_()),
+    ]
+    assert PATROL_TYPES_SCHEMA_V1.names == [n for n, _ in expected]
+    for name, typ in expected:
+        assert PATROL_TYPES_SCHEMA_V1.field(name).type == typ
+
+
+def test_patrol_types_schema_v1_does_not_carry_the_schema_document():
+    """The schema document is served as Arrow IPC schema bytes or a JSON mapping
+    by the schema endpoints, never as a column of the listing -- same rule as
+    EVENT_TYPES_SCHEMA_V1."""
+    assert "schema" not in PATROL_TYPES_SCHEMA_V1.names
+
+
+def test_capture_fields_round_trip_populated_values():
+    """The resolved structs carry what a consumer needs without a das call: a
+    team's display name, and a member's name and type."""
+    row = {
+        "id": "e1",
+        "patrol_id": "p1",
+        "segment_details": '{"objective": "north fence"}',
+        "type_details": "{}",
+        "team": {
+            "id": "t1",
+            "value": "alpha",
+            "display": "Alpha",
+            "ordernum": 1,
+            "is_active": True,
+        },
+        "members": [
+            {
+                "id": "m1",
+                "name": "Ranger Ali",
+                "subject_type": "person",
+                "subject_subtype": "ranger",
+                "subject_subtype_display": "Ranger",
+                "is_active": True,
+            }
+        ],
+        "assets": [],
+        "is_pause": False,
+    }
+    out = pa.Table.from_pylist([row], schema=PATROL_EVENTS_FLAT_SCHEMA_V1).to_pylist()[
+        0
+    ]
+    assert out["team"]["display"] == "Alpha"
+    assert out["members"][0]["subject_type"] == "person"
+    # An empty roster is [] and a non-pause is False -- distinct from the null
+    # that means "not captured". Both survive the round trip.
+    assert out["assets"] == []
+    assert out["is_pause"] is False
+    assert out["type_details"] == "{}"
+
+
+def test_member_order_survives_an_ipc_round_trip():
+    """Why PATROL_SEGMENT_SUBJECT_STRUCT_V1 carries no ``ordernum``: an Arrow
+    list is ordered by construction, so the order the API applies from the link
+    tables' ordernum reaches the client intact through the IPC stream the client
+    reads with ``pa.ipc.open_stream``."""
+    members = [
+        {
+            "id": str(i),
+            "name": f"member-{i}",
+            "subject_type": "person",
+            "subject_subtype": None,
+            "subject_subtype_display": None,
+            "is_active": True,
+        }
+        for i in range(5)
+    ]
+    table = pa.Table.from_pylist(
+        [{"id": "p1", "patrol_segments": [{"id": "s1", "members": members}]}],
+        schema=PATROLS_WITH_EVENTS_NESTED_SCHEMA_V1,
+    )
+    sink = pa.BufferOutputStream()
+    with pa.ipc.new_stream(sink, table.schema) as writer:
+        writer.write_table(table)
+    back = pa.ipc.open_stream(sink.getvalue()).read_all()
+    read_members = back.to_pylist()[0]["patrol_segments"][0]["members"]
+    assert [m["id"] for m in read_members] == ["0", "1", "2", "3", "4"]

--- a/tests/test_patrols_query.py
+++ b/tests/test_patrols_query.py
@@ -1,0 +1,125 @@
+import pytest
+from pydantic import ValidationError
+
+from ecoscope_earthranger_io_core.query import (
+    PatrolsQuery,
+    PatrolTypeSchemaQuery,
+    PatrolTypesQuery,
+    SegmentSchemaQuery,
+)
+
+
+DOMAIN = "example.pamdas.org"
+
+# Every PatrolsQuery field that existed before this change, with its default.
+# The new options must not disturb any of them.
+PRE_EXISTING_PATROLS_DEFAULTS = {
+    "range_start": None,
+    "range_end": None,
+    "patrol_ids": None,
+    "patrol_type_value": None,
+    "patrol_status": None,
+    "patrols_overlap_daterange": True,
+    "include_patrol_segments": False,
+    "include_events": True,
+    "flat": True,
+}
+
+
+def test_patrols_query_existing_defaults_are_unchanged():
+    """A caller that passes none of the new options must behave exactly as
+    before -- the new fields are additive inputs, not a behaviour change."""
+    q = PatrolsQuery(tenant_domain=DOMAIN)
+    for name, default in PRE_EXISTING_PATROLS_DEFAULTS.items():
+        assert getattr(q, name) == default
+
+
+def test_patrols_query_excludes_pauses_by_default():
+    """das excludes paused legs by default so patrol totals match the product;
+    the warehouse query mirrors that."""
+    assert PatrolsQuery(tenant_domain=DOMAIN).include_pauses is False
+
+
+def test_patrols_query_detail_options_default_to_typed():
+    assert PatrolsQuery(tenant_domain=DOMAIN).raw_details is False
+    assert PatrolsQuery(tenant_domain=DOMAIN).parse_detail_datetimes is False
+
+
+@pytest.mark.parametrize(
+    "field", ["include_pauses", "raw_details", "parse_detail_datetimes"]
+)
+@pytest.mark.parametrize("value", [True, False])
+def test_patrols_query_new_flags_round_trip(field, value):
+    q = PatrolsQuery(**{"tenant_domain": DOMAIN, field: value})
+    assert getattr(q, field) is value
+    assert q.model_dump()[field] is value
+
+
+def test_patrols_query_from_query_params_round_trip():
+    # ``from_query_params`` is a FastAPI dependency; when called directly we must
+    # pass every parameter explicitly so the ``Query(...)`` sentinels don't leak
+    # into pydantic.
+    q = PatrolsQuery.from_query_params(
+        tenant_domain=DOMAIN,
+        range_start=None,
+        range_end=None,
+        patrol_ids=None,
+        patrol_type_value=None,
+        patrol_status=None,
+        patrols_overlap_daterange=True,
+        include_patrol_segments=False,
+        include_events=True,
+        flat=True,
+        include_pauses=True,
+        raw_details=True,
+        parse_detail_datetimes=True,
+    )
+    assert q.include_pauses is True
+    assert q.raw_details is True
+    assert q.parse_detail_datetimes is True
+
+
+def test_patrol_types_query_is_tenant_scoped():
+    q = PatrolTypesQuery(tenant_domain=DOMAIN)
+    assert q.tenant_domain == DOMAIN
+    assert q.include_schema is False
+    # tenant_id is resolved server-side and must never be settable by a caller.
+    assert "tenant_id" not in q.model_dump()
+
+
+@pytest.mark.parametrize("value", [True, False])
+def test_patrol_types_query_include_schema_round_trip(value):
+    q = PatrolTypesQuery.from_query_params(tenant_domain=DOMAIN, include_schema=value)
+    assert q.include_schema is value
+
+
+def test_patrol_type_schema_query_requires_its_key():
+    q = PatrolTypeSchemaQuery(tenant_domain=DOMAIN, patrol_type_value="routine_patrol")
+    assert q.patrol_type_value == "routine_patrol"
+    with pytest.raises(ValidationError):
+        PatrolTypeSchemaQuery(tenant_domain=DOMAIN)
+
+
+def test_patrol_type_schema_query_accepts_a_uuid_for_its_key():
+    """das keys a patrol type by either its UUID or its ``value`` slug. One
+    field takes both spellings, so a caller cannot set two conflicting keys."""
+    uuid = "c4d5e6f7-1a2b-4c3d-8e9f-0a1b2c3d4e5f"
+    q = PatrolTypeSchemaQuery.from_query_params(
+        tenant_domain=DOMAIN, patrol_type_value=uuid
+    )
+    assert q.patrol_type_value == uuid
+
+
+def test_segment_schema_query_is_keyed_only_by_tenant():
+    """There is exactly one segment schema per tenant, so tenant is the whole
+    key -- and that is why segment_details can always be served typed."""
+    q = SegmentSchemaQuery.from_query_params(tenant_domain=DOMAIN)
+    assert q.model_dump() == {"tenant_domain": DOMAIN}
+
+
+@pytest.mark.parametrize(
+    "model", [PatrolTypesQuery, PatrolTypeSchemaQuery, SegmentSchemaQuery]
+)
+def test_schema_queries_require_a_tenant(model):
+    with pytest.raises(ValidationError):
+        model()

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -151,5 +151,8 @@ def test_patrols_query_from_query_params_patrols_overlap_daterange(value):
         include_patrol_segments=False,
         include_events=False,
         flat=True,
+        include_pauses=False,
+        raw_details=False,
+        parse_detail_datetimes=False,
     )
     assert q.patrols_overlap_daterange is value


### PR DESCRIPTION
## :earth_americas: Summary
Adds the query models and Arrow schemas for patrol type schemas, the site-wide segment schema, and the new patrol-leg capture fields — the contract that the DWH API and the DWH client both build against.

### :package: Proposed Changes
- Add `PatrolTypesQuery`, `PatrolTypeSchemaQuery` and `SegmentSchemaQuery`, and `include_pauses`/`raw_details`/`parse_detail_datetimes` on `PatrolsQuery`.
- Publish `PATROL_TYPES_SCHEMA_V1` and append the leg capture fields  (`segment_details`, `type_details`, `team`, `members`, `assets`, `is_pause`) to `PATROL_SEGMENT_STRUCT_V1` and the schemas that embed it.
