### PR TITLE
Switch to trusted publishing for prefix releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,8 @@ jobs:
     if: startsWith(github.ref, 'refs/tags/')
 
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
     steps:
       - name: Download conda channel
         uses: actions/download-artifact@v4
@@ -56,8 +58,6 @@ jobs:
       - name: Install pixi
         run: curl -fsSL https://pixi.sh/install.sh | bash && echo "$HOME/.pixi/bin" >> $GITHUB_PATH
       - name: Publish to prefix.dev
-        env:
-          PREFIX_API_KEY: ${{ secrets.PREFIX_API_KEY }}
         run: pixi run -e publish push-all
 
   github-release:


### PR DESCRIPTION
## :earth_americas: Summary
Towards https://github.com/wildlife-dynamics/compose/issues/2740

### :package: Proposed Changes
Removes PREFIX_API_KEY, and sets `id-token: write` perms
Trusted publishing config on the prefix repo has been configured